### PR TITLE
fix: offload blocking adapter I/O off the event loop (v0.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.22.0] - 2026-06-02
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **Async tool handlers no longer block the event loop on synchronous adapter I/O.** The nine tool handlers in `tools/factory.py` are `async def`, but four of them called **synchronous**, blocking `DatabaseAdapter` / `ExplainAdapter` methods directly on the event-loop thread. A single slow query (tens of seconds, common for analytical warehouses) therefore stalled the **entire asyncio event loop of the host process** — freezing every other concurrent coroutine: other sessions' tool calls, health-check probes, and anything else sharing the loop. This is invisible at low concurrency but becomes the dominant latency multiplier once multiple sessions share one host process (e.g. a shared in-process MCP server backing a multi-user bot). Each blocking round-trip is now offloaded via `asyncio.to_thread(...)`: `adapter.execute` (in `run_query` and `preview_table`), `adapter.describe_table` (in `describe_table`), and `validator.validate`'s EXPLAIN dry-run (`explain_adapter.explain`, used by `run_query` and `inspect_query`).
+- **Async enforcement paths no longer block the event loop on synchronous adapter I/O.** The `async def` handlers across the tools layer called **synchronous**, blocking `DatabaseAdapter` / `ExplainAdapter` methods directly on the event-loop thread. A single slow query (tens of seconds, common for analytical warehouses) therefore stalled the **entire asyncio event loop of the host process** — freezing every other concurrent coroutine: other sessions' tool calls, health-check probes, and anything else sharing the loop. This is invisible at low concurrency but becomes the dominant latency multiplier once multiple sessions share one host process (e.g. a shared in-process MCP server backing a multi-user bot). Each blocking round-trip is now offloaded via `asyncio.to_thread(...)` in every async path:
+  - **`tools/factory.py`** — `adapter.execute` (in `run_query` and `preview_table`), `adapter.describe_table` (in `describe_table`), and `validator.validate`'s EXPLAIN dry-run (`explain_adapter.explain`, used by `run_query` and `inspect_query`).
+  - **`tools/middleware.py`** — `contract_middleware`'s async wrapper now offloads `validator.validate`.
+  - **`tools/langchain.py`** — `ContractMiddleware.awrap_tool_call` now offloads its `_check` (which runs `validator.validate`); the synchronous `wrap_tool_call` path is unchanged.
 
 ### Compatibility
 
@@ -16,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - 4 tests in `tests/test_tools/test_event_loop.py` asserting that `run_query`, `inspect_query`, `describe_table`, and `preview_table` execute their blocking adapter calls on a worker thread rather than the event-loop thread.
+- Matching off-loop tests for the other two async enforcement paths: `test_middleware_offloads_validate_off_event_loop` (`contract_middleware`) and `test_contract_middleware_offloads_validate_off_event_loop` (LangChain `ContractMiddleware.awrap_tool_call`).
 
 ## [0.21.1] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Async tool handlers no longer block the event loop on synchronous adapter I/O.** The nine tool handlers in `tools/factory.py` are `async def`, but four of them called **synchronous**, blocking `DatabaseAdapter` / `ExplainAdapter` methods directly on the event-loop thread. A single slow query (tens of seconds, common for analytical warehouses) therefore stalled the **entire asyncio event loop of the host process** — freezing every other concurrent coroutine: other sessions' tool calls, health-check probes, and anything else sharing the loop. This is invisible at low concurrency but becomes the dominant latency multiplier once multiple sessions share one host process (e.g. a shared in-process MCP server backing a multi-user bot). Each blocking round-trip is now offloaded via `asyncio.to_thread(...)`: `adapter.execute` (in `run_query` and `preview_table`), `adapter.describe_table` (in `describe_table`), and `validator.validate`'s EXPLAIN dry-run (`explain_adapter.explain`, used by `run_query` and `inspect_query`).
+
+### Compatibility
+
+- **No API change.** The synchronous `DatabaseAdapter` / `ExplainAdapter` protocols are unchanged — this is a purely internal change to how the async handlers invoke them, so existing consumers (and custom adapters) need no changes.
+- **Connection pool, not thread pool, remains the concurrency gate.** `asyncio.to_thread` uses the event loop's default `ThreadPoolExecutor`; concurrent DB work stays bounded by the adapter's own connection pool. Consumers should size that pool to the concurrency they want to support (now documented in `docs/architecture.md`).
+
+### Added
+
+- 4 tests in `tests/test_tools/test_event_loop.py` asserting that `run_query`, `inspect_query`, `describe_table`, and `preview_table` execute their blocking adapter calls on a worker thread rather than the event-loop thread.
+
 ## [0.21.1] - 2026-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
   - **`tools/factory.py`** — `adapter.execute` (in `run_query` and `preview_table`), `adapter.describe_table` (in `describe_table`), and `validator.validate`'s EXPLAIN dry-run (`explain_adapter.explain`, used by `run_query` and `inspect_query`).
   - **`tools/middleware.py`** — `contract_middleware`'s async wrapper now offloads `validator.validate`.
   - **`tools/langchain.py`** — `ContractMiddleware.awrap_tool_call` now offloads its `_check` (which runs `validator.validate`); the synchronous `wrap_tool_call` path is unchanged.
+- **`DuckDBAdapter` is now safe under the concurrency the offloading enables.** A single DuckDB connection is not safe for concurrent queries across threads, and the new `asyncio.to_thread` offloading lets multiple sessions land in `execute` / `explain` / `describe_table` on different worker threads at once. The adapter now guards every access to its shared connection with a `threading.Lock`, so concurrent calls serialize on the connection instead of interleaving and corrupting each other's result state. DuckDB still parallelizes the work of an individual query internally; the lock only prevents two queries from interleaving on the same connection.
 
 ### Compatibility
 
@@ -20,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 - 4 tests in `tests/test_tools/test_event_loop.py` asserting that `run_query`, `inspect_query`, `describe_table`, and `preview_table` execute their blocking adapter calls on a worker thread rather than the event-loop thread.
 - Matching off-loop tests for the other two async enforcement paths: `test_middleware_offloads_validate_off_event_loop` (`contract_middleware`) and `test_contract_middleware_offloads_validate_off_event_loop` (LangChain `ContractMiddleware.awrap_tool_call`).
+- `test_execute_serializes_concurrent_connection_access` in `tests/test_adapters/test_duckdb.py`, which fires 8 concurrent `execute` calls through `asyncio.to_thread` and asserts the adapter lock holds peak connection concurrency at 1.
 
 ## [0.21.1] - 2026-05-30
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -456,6 +456,14 @@ connection pool**, not the thread pool — connections are the real concurrency
 gate. Size your adapter's connection pool to the concurrency you want to
 support.
 
+Because the offloaded calls now run on worker threads, an adapter must be safe
+for concurrent invocation. Implementations backed by a connection pool get this
+for free; an adapter that shares a single connection must serialize access to
+it. The bundled `DuckDBAdapter` holds a single connection — which is not safe
+for concurrent queries — so it guards `execute` / `explain` / `describe_table`
+with a `threading.Lock`, serializing on the connection rather than interleaving.
+Custom single-connection adapters should do the same.
+
 ## Semantic Layer
 
 Reads external semantic definitions so the agent knows *how* metrics are defined.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -422,6 +422,34 @@ async def my_custom_query_tool(args: dict) -> dict:
 | `run_query` | Fully functional when database adapter is configured |
 | `inspect_query` | Layer 1 always runs; EXPLAIN fields populated when adapter is configured |
 
+### Concurrency & Event-Loop Safety
+
+The tool handlers are `async def`, but the `DatabaseAdapter` / `ExplainAdapter`
+protocols are deliberately **synchronous**. To keep the public adapter contract
+simple while never stalling the host's asyncio event loop, every blocking
+adapter round-trip in the async handlers is offloaded to a worker thread via
+`asyncio.to_thread(...)`:
+
+| Tool | Offloaded call |
+|---|---|
+| `run_query` | `validator.validate` (EXPLAIN dry-run) + `adapter.execute` |
+| `inspect_query` | `validator.validate` (EXPLAIN dry-run) |
+| `describe_table` | `adapter.describe_table` |
+| `preview_table` | `adapter.execute` |
+
+This matters when one host process serves multiple concurrent sessions on a
+single event loop (e.g. a shared in-process MCP server backing a multi-user
+bot): without offloading, a single 30–60s analytical query would freeze every
+other coroutine — other sessions' tool calls, health-check probes, and so on.
+Offloading keeps the adapter contract unchanged, so existing consumers need no
+code changes.
+
+`asyncio.to_thread` uses the event loop's default `ThreadPoolExecutor`.
+Concurrent database work is therefore naturally bounded by **the adapter's own
+connection pool**, not the thread pool — connections are the real concurrency
+gate. Size your adapter's connection pool to the concurrency you want to
+support.
+
 ## Semantic Layer
 
 Reads external semantic definitions so the agent knows *how* metrics are defined.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -437,6 +437,12 @@ adapter round-trip in the async handlers is offloaded to a worker thread via
 | `describe_table` | `adapter.describe_table` |
 | `preview_table` | `adapter.execute` |
 
+The two graph-/decorator-level enforcement entry points apply the same offload
+on their async paths: `contract_middleware`'s async wrapper and the LangChain
+`ContractMiddleware.awrap_tool_call` both run `validator.validate` (and its
+EXPLAIN dry-run) via `asyncio.to_thread`. The synchronous `wrap_tool_call`
+path is left as-is — it is not on an event loop.
+
 This matters when one host process serves multiple concurrent sessions on a
 single event loop (e.g. a shared in-process MCP server backing a multi-user
 bot): without offloading, a single 30–60s analytical query would freeze every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.21.1"
+version = "0.22.0"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/adapters/duckdb.py
+++ b/src/agentic_data_contracts/adapters/duckdb.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 import duckdb
 
 from agentic_data_contracts.adapters.base import Column, QueryResult, TableSchema
@@ -9,25 +11,38 @@ from agentic_data_contracts.validation.explain import ExplainResult
 
 
 class DuckDBAdapter:
-    """Database adapter for DuckDB."""
+    """Database adapter for DuckDB.
+
+    A single DuckDB connection is **not** safe for concurrent queries from
+    multiple threads. The async tool handlers offload adapter calls via
+    ``asyncio.to_thread`` (see ``tools/factory.py``), so concurrent sessions
+    can land here on different worker threads at once. ``_lock`` serializes
+    every access to ``self.connection`` so the shared connection stays
+    consistent. DuckDB still parallelizes the work of an individual query
+    internally; the lock only prevents two queries from interleaving on the
+    same connection.
+    """
 
     def __init__(self, database: str = ":memory:") -> None:
         self.connection = duckdb.connect(database)
+        self._lock = threading.Lock()
 
     @property
     def dialect(self) -> str:
         return "duckdb"
 
     def execute(self, sql: str) -> QueryResult:
-        result = self.connection.execute(sql)
-        columns = [desc[0] for desc in result.description]
-        rows = result.fetchall()
+        with self._lock:
+            result = self.connection.execute(sql)
+            columns = [desc[0] for desc in result.description]
+            rows = result.fetchall()
         return QueryResult(columns=columns, rows=rows)
 
     def explain(self, sql: str) -> ExplainResult:
         try:
-            result = self.connection.execute(f"EXPLAIN {sql}")
-            rows = result.fetchall()
+            with self._lock:
+                result = self.connection.execute(f"EXPLAIN {sql}")
+                rows = result.fetchall()
             estimated_rows = self._parse_row_estimate(rows)
             return ExplainResult(
                 estimated_cost_usd=None,
@@ -60,27 +75,29 @@ class DuckDBAdapter:
         return last_estimate
 
     def list_tables(self, schema: str) -> list[str]:
-        rows = self.connection.execute(
-            """
-            SELECT table_name
-            FROM information_schema.tables
-            WHERE table_schema = ?
-            ORDER BY table_name
-            """,
-            [schema],
-        ).fetchall()
+        with self._lock:
+            rows = self.connection.execute(
+                """
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_schema = ?
+                ORDER BY table_name
+                """,
+                [schema],
+            ).fetchall()
         return [row[0] for row in rows]
 
     def describe_table(self, schema: str, table: str) -> TableSchema:
-        rows = self.connection.execute(
-            """
-            SELECT column_name, data_type, is_nullable
-            FROM information_schema.columns
-            WHERE table_schema = ? AND table_name = ?
-            ORDER BY ordinal_position
-            """,
-            [schema, table],
-        ).fetchall()
+        with self._lock:
+            rows = self.connection.execute(
+                """
+                SELECT column_name, data_type, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = ? AND table_name = ?
+                ORDER BY ordinal_position
+                """,
+                [schema, table],
+            ).fetchall()
         columns = [
             Column(
                 name=row[0],

--- a/src/agentic_data_contracts/tools/factory.py
+++ b/src/agentic_data_contracts/tools/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import dataclass
@@ -243,7 +244,11 @@ def create_tools(
                 f"No database adapter configured — table description unavailable"
                 f" for {qualified}."
             )
-        ts = adapter.describe_table(schema_name, table_name)
+        # Offload the synchronous DB round-trip to a worker thread so a slow
+        # warehouse call cannot stall the host's asyncio event loop (and every
+        # other coroutine sharing it). The sync DatabaseAdapter contract is
+        # unchanged. See tests/test_tools/test_event_loop.py.
+        ts = await asyncio.to_thread(adapter.describe_table, schema_name, table_name)
         # Overlay authored descriptions from the semantic source onto adapter
         # output. Semantic source wins because it is the canonical agent-facing
         # documentation; adapter-supplied descriptions (e.g. warehouse column
@@ -352,7 +357,10 @@ def create_tools(
                 + "\nUse run_query with explicit columns instead."
             )
 
-        result = adapter.execute(f"SELECT * FROM {qualified} LIMIT {limit}")
+        # Offload the blocking DB round-trip — see describe_table above.
+        result = await asyncio.to_thread(
+            adapter.execute, f"SELECT * FROM {qualified} LIMIT {limit}"
+        )
         rows = [dict(zip(result.columns, row)) for row in result.rows]
         body = json.dumps({"schema": schema, "table": table, "rows": rows}, default=str)
         # Symmetric with run_query: surface warn/log enforcement so audit
@@ -624,7 +632,10 @@ def create_tools(
     # ── Tool 8: inspect_query ─────────────────────────────────────────────────
     async def inspect_query(args: dict[str, Any]) -> dict[str, Any]:
         sql = args.get("sql", "")
-        result = validator.validate(sql)
+        # validate() runs a synchronous EXPLAIN/dry-run round-trip to the DB
+        # (validator.py:307) when an explain adapter is configured, so offload
+        # it to a worker thread to keep the event loop responsive.
+        result = await asyncio.to_thread(validator.validate, sql)
         data: dict[str, Any] = {
             "valid": not result.blocked,
             "violations": list(result.reasons),
@@ -655,8 +666,10 @@ def create_tools(
                 _with_remaining(f"BLOCKED — Session limit exceeded: {e}")
             )
 
-        # Phase 1 + 2: query checks + EXPLAIN
-        vresult = validator.validate(sql)
+        # Phase 1 + 2: query checks + EXPLAIN. validate() makes a synchronous
+        # EXPLAIN/dry-run DB round-trip (validator.py:307), so offload it to a
+        # worker thread to avoid blocking the event loop.
+        vresult = await asyncio.to_thread(validator.validate, sql)
         if vresult.blocked:
             session.record_retry()
             msg = "BLOCKED — Violations:\n" + "\n".join(
@@ -677,7 +690,10 @@ def create_tools(
             )
 
         try:
-            qresult = adapter.execute(sql)
+            # Offload the query execution — the dominant blocking call — off
+            # the event loop. Concurrent DB work stays bounded by the adapter's
+            # own connection pool, not the thread pool.
+            qresult = await asyncio.to_thread(adapter.execute, sql)
         except Exception as e:  # noqa: BLE001
             session.record_retry()
             return _text_response(

--- a/src/agentic_data_contracts/tools/langchain.py
+++ b/src/agentic_data_contracts/tools/langchain.py
@@ -32,6 +32,7 @@ Requires the ``[langchain]`` extra: ``pip install agentic-data-contracts[langcha
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -266,7 +267,11 @@ class ContractMiddleware(AgentMiddleware):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
-        blocked = self._check(request)
+        # _check runs the synchronous Validator.validate(), which makes a
+        # blocking EXPLAIN/dry-run DB round-trip (validator.py:307). Offload it
+        # to a worker thread so a slow check cannot stall the event loop in an
+        # async runtime. The sync wrap_tool_call path calls _check directly.
+        blocked = await asyncio.to_thread(self._check, request)
         if blocked is not None:
             return blocked
         return await handler(request)

--- a/src/agentic_data_contracts/tools/middleware.py
+++ b/src/agentic_data_contracts/tools/middleware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import functools
 from collections.abc import Callable
 from typing import Any
@@ -47,7 +48,10 @@ def contract_middleware(
 
             sql = args.get("sql", "")
             if sql:
-                result = validator.validate(sql)
+                # validate() makes a synchronous EXPLAIN/dry-run DB round-trip
+                # (validator.py:307), so offload it to a worker thread to keep
+                # the event loop responsive — same rationale as factory.py.
+                result = await asyncio.to_thread(validator.validate, sql)
                 if result.blocked:
                     session.record_retry()
                     return {

--- a/tests/test_adapters/test_duckdb.py
+++ b/tests/test_adapters/test_duckdb.py
@@ -1,3 +1,7 @@
+import asyncio
+import threading
+import time
+
 import pytest
 
 from agentic_data_contracts.adapters.base import (
@@ -76,3 +80,58 @@ def test_describe_table_types(adapter: DuckDBAdapter) -> None:
     col_map = {c.name: c for c in schema.columns}
     assert "INTEGER" in col_map["id"].type.upper()
     assert "VARCHAR" in col_map["tenant_id"].type.upper()
+
+
+@pytest.mark.asyncio
+async def test_execute_serializes_concurrent_connection_access(
+    adapter: DuckDBAdapter,
+) -> None:
+    """The internal lock must prevent two threads from interleaving on the
+    single shared DuckDB connection.
+
+    The async tool handlers offload ``adapter.execute`` via
+    ``asyncio.to_thread``, so concurrent sessions can call it from different
+    worker threads at once. We instrument the underlying
+    ``connection.execute`` to record peak in-flight concurrency: with the
+    lock it must never exceed 1. Without the lock, the overlapping
+    ``time.sleep`` windows below would push the peak above 1.
+    """
+    counter_lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    # The DuckDB C connection's ``execute`` is read-only, so wrap the whole
+    # connection in a proxy that instruments ``execute`` and delegates the
+    # rest (``description``/``fetchall`` live on the returned result object).
+    class _TrackingConn:
+        def __init__(self, real) -> None:  # type: ignore[no-untyped-def]
+            self._real = real
+
+        def execute(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal active, peak
+            with counter_lock:
+                active += 1
+                peak = max(peak, active)
+            try:
+                time.sleep(0.02)  # widen the window so an unlocked path overlaps
+                return self._real.execute(*args, **kwargs)
+            finally:
+                with counter_lock:
+                    active -= 1
+
+        def __getattr__(self, name):  # type: ignore[no-untyped-def]
+            return getattr(self._real, name)
+
+    setattr(adapter, "connection", _TrackingConn(adapter.connection))
+
+    results = await asyncio.gather(
+        *(
+            asyncio.to_thread(
+                adapter.execute, "SELECT id FROM analytics.orders ORDER BY id"
+            )
+            for _ in range(8)
+        )
+    )
+
+    assert peak == 1, f"connection access interleaved (peak concurrency={peak})"
+    assert all(len(r.rows) == 2 for r in results)

--- a/tests/test_tools/test_event_loop.py
+++ b/tests/test_tools/test_event_loop.py
@@ -1,0 +1,126 @@
+"""Async tool handlers must not run blocking adapter I/O on the event loop.
+
+The tool handlers in ``tools/factory.py`` are ``async def`` but the underlying
+``DatabaseAdapter`` / ``ExplainAdapter`` methods are synchronous and may make
+slow DB round-trips. Those calls must be offloaded to a worker thread (via
+``asyncio.to_thread``) so a single slow query cannot stall the host's event
+loop and every other coroutine sharing it.
+
+These tests assert the blocking adapter calls execute on a *different* thread
+than the event loop, which is the observable consequence of offloading.
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from agentic_data_contracts.adapters.duckdb import DuckDBAdapter
+from agentic_data_contracts.core.contract import DataContract
+from agentic_data_contracts.semantic.yaml_source import YamlSource
+from agentic_data_contracts.tools.factory import create_tools
+
+
+@pytest.fixture
+def contract(fixtures_dir: Path) -> DataContract:
+    return DataContract.from_yaml(fixtures_dir / "valid_contract.yml")
+
+
+@pytest.fixture
+def adapter() -> DuckDBAdapter:
+    db = DuckDBAdapter(":memory:")
+    db.connection.execute(
+        """
+        CREATE SCHEMA IF NOT EXISTS analytics;
+        CREATE TABLE analytics.orders (
+            id INTEGER, amount DECIMAL(10,2), tenant_id VARCHAR
+        );
+        INSERT INTO analytics.orders VALUES (1, 100.00, 'acme'), (2, 200.00, 'acme');
+        """
+    )
+    return db
+
+
+@pytest.fixture
+def semantic(fixtures_dir: Path) -> YamlSource:
+    return YamlSource(fixtures_dir / "semantic_source.yml")
+
+
+def _track_thread(adapter: DuckDBAdapter, method: str, seen: dict[str, int]) -> None:
+    """Wrap ``adapter.method`` to record the thread it executes on."""
+    original = getattr(adapter, method)
+
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+        seen[method] = threading.get_ident()
+        return original(*args, **kwargs)
+
+    setattr(adapter, method, wrapper)
+
+
+@pytest.mark.asyncio
+async def test_run_query_offloads_execute_and_explain(
+    contract: DataContract, adapter: DuckDBAdapter, semantic: YamlSource
+) -> None:
+    seen: dict[str, int] = {}
+    _track_thread(adapter, "execute", seen)
+    _track_thread(adapter, "explain", seen)
+
+    tools = create_tools(contract, adapter=adapter, semantic_source=semantic)
+    tool = next(t for t in tools if t.name == "run_query")
+    await tool.callable(
+        {"sql": "SELECT id, amount FROM analytics.orders WHERE tenant_id = 'acme'"}
+    )
+
+    main_thread = threading.get_ident()
+    assert seen["explain"] != main_thread, "EXPLAIN ran on the event-loop thread"
+    assert seen["execute"] != main_thread, "execute ran on the event-loop thread"
+
+
+@pytest.mark.asyncio
+async def test_inspect_query_offloads_explain(
+    contract: DataContract, adapter: DuckDBAdapter, semantic: YamlSource
+) -> None:
+    seen: dict[str, int] = {}
+    _track_thread(adapter, "explain", seen)
+
+    tools = create_tools(contract, adapter=adapter, semantic_source=semantic)
+    tool = next(t for t in tools if t.name == "inspect_query")
+    await tool.callable(
+        {"sql": "SELECT id, amount FROM analytics.orders WHERE tenant_id = 'acme'"}
+    )
+
+    assert seen["explain"] != threading.get_ident(), (
+        "EXPLAIN ran on the event-loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_describe_table_offloads_adapter_call(
+    contract: DataContract, adapter: DuckDBAdapter, semantic: YamlSource
+) -> None:
+    seen: dict[str, int] = {}
+    _track_thread(adapter, "describe_table", seen)
+
+    tools = create_tools(contract, adapter=adapter, semantic_source=semantic)
+    tool = next(t for t in tools if t.name == "describe_table")
+    await tool.callable({"schema": "analytics", "table": "orders"})
+
+    assert seen["describe_table"] != threading.get_ident(), (
+        "describe_table ran on the event-loop thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_table_offloads_execute(
+    contract: DataContract, adapter: DuckDBAdapter, semantic: YamlSource
+) -> None:
+    seen: dict[str, int] = {}
+    _track_thread(adapter, "execute", seen)
+
+    tools = create_tools(contract, adapter=adapter, semantic_source=semantic)
+    tool = next(t for t in tools if t.name == "preview_table")
+    await tool.callable({"schema": "analytics", "table": "orders"})
+
+    assert seen["execute"] != threading.get_ident(), (
+        "execute ran on the event-loop thread"
+    )

--- a/tests/test_tools/test_langchain.py
+++ b/tests/test_tools/test_langchain.py
@@ -1,5 +1,6 @@
 """Tests for LangChain / deepagents BaseTool adapter."""
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -395,6 +396,49 @@ def test_contract_middleware_blocks_disallowed_sql_via_wrap_tool_call_sync(
     assert result.status == "error"
     assert "BLOCKED" in str(result.content)
     assert result.tool_call_id == "tc-sync"
+
+
+@pytest.mark.asyncio
+async def test_contract_middleware_offloads_validate_off_event_loop(
+    contract: DataContract, adapter: DuckDBAdapter
+) -> None:
+    """awrap_tool_call must run the blocking EXPLAIN dry-run (inside
+    Validator.validate, via _check) on a worker thread, not the event-loop
+    thread."""
+    from langchain.agents.middleware.types import ToolCallRequest
+    from langchain_core.messages import ToolMessage
+
+    seen: dict[str, int] = {}
+    original_explain = adapter.explain
+
+    def tracking_explain(sql: str):  # type: ignore[no-untyped-def]
+        seen["explain"] = threading.get_ident()
+        return original_explain(sql)
+
+    setattr(adapter, "explain", tracking_explain)
+
+    mw = ContractMiddleware(contract, adapter=adapter)
+    request = ToolCallRequest(
+        tool_call={
+            "name": "run_query",
+            "args": {
+                "sql": "SELECT id FROM analytics.orders WHERE tenant_id = 'acme'",
+            },
+            "id": "tc-thread",
+            "type": "tool_call",
+        },
+        tool=None,
+        state={},
+        runtime=None,  # ty: ignore[invalid-argument-type]
+    )
+
+    async def _handler(_req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="ok", tool_call_id="tc-thread")
+
+    await mw.awrap_tool_call(request, _handler)
+    assert seen["explain"] != threading.get_ident(), (
+        "EXPLAIN ran on the event-loop thread"
+    )
 
 
 # ─── top-level lazy re-export ─────────────────────────────────────────────────

--- a/tests/test_tools/test_middleware.py
+++ b/tests/test_tools/test_middleware.py
@@ -1,3 +1,4 @@
+import threading
 from pathlib import Path
 
 import pytest
@@ -91,3 +92,31 @@ async def test_middleware_checks_session_limits(
     )
     text = result["content"][0]["text"]
     assert "limit" in text.lower() or "exceeded" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_middleware_offloads_validate_off_event_loop(
+    contract: DataContract, adapter: DuckDBAdapter
+) -> None:
+    """The async wrapper must run the blocking EXPLAIN dry-run (inside
+    validator.validate) on a worker thread, not the event-loop thread."""
+    seen: dict[str, int] = {}
+    original_explain = adapter.explain
+
+    def tracking_explain(sql: str):  # type: ignore[no-untyped-def]
+        seen["explain"] = threading.get_ident()
+        return original_explain(sql)
+
+    setattr(adapter, "explain", tracking_explain)
+
+    @contract_middleware(contract, adapter=adapter)
+    async def my_query(args: dict) -> dict:
+        return {"content": [{"type": "text", "text": "ok"}]}
+
+    await my_query(
+        {"sql": "SELECT id, amount FROM analytics.orders WHERE tenant_id = 'acme'"}
+    )
+
+    assert seen["explain"] != threading.get_ident(), (
+        "EXPLAIN ran on the event-loop thread"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.21.1"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Fixes #23. The `async def` enforcement handlers across the tools layer called **synchronous**, blocking `DatabaseAdapter` / `ExplainAdapter` methods directly on the event-loop thread. A single slow query (tens of seconds, common for analytical warehouses) therefore stalled the **entire asyncio event loop of the host process** — freezing every other concurrent coroutine: other sessions' tool calls, health-check probes, and anything else sharing the loop.

Each blocking round-trip is now offloaded via `asyncio.to_thread(...)`, leaving the synchronous `DatabaseAdapter` / `ExplainAdapter` protocols **unchanged** so existing consumers (and custom adapters) need no changes.

### What changed

- **`tools/factory.py`** — offloads `adapter.execute` (in `run_query` and `preview_table`), `adapter.describe_table` (in `describe_table`), and `validator.validate`'s EXPLAIN dry-run (`explain_adapter.explain`, used by `run_query` and `inspect_query`).
- **`tools/middleware.py`** — `contract_middleware`'s async wrapper now offloads `validator.validate`.
- **`tools/langchain.py`** — `ContractMiddleware.awrap_tool_call` now offloads its `_check` (which runs `validator.validate`); the synchronous `wrap_tool_call` path is intentionally unchanged since it is not on an event loop.

The latter two paths were caught in a follow-up code review — they share the exact blocking pattern fixed in `factory.py`, so the fix is applied consistently across all three async enforcement entry points.

### Why minor (0.22.0)

This alters runtime concurrency behavior (matching the precedent of `0.21.0`, a library behavioral "Fixed" → minor bump). There is **no API or observable-output change**: the sync adapter contract is identical, and concurrent DB work stays bounded by the adapter's own connection pool, not the thread pool (now documented in `docs/architecture.md`).

## Test plan

- [x] 6 new tests asserting the blocking adapter calls execute on a worker thread rather than the event-loop thread:
  - `tests/test_tools/test_event_loop.py` — `run_query`, `inspect_query`, `describe_table`, `preview_table`
  - `tests/test_tools/test_middleware.py` — `contract_middleware`
  - `tests/test_tools/test_langchain.py` — LangChain `ContractMiddleware.awrap_tool_call`
- [x] Full suite: **608 passed**
- [x] `ruff check` + `ruff format --check`: clean
- [x] `ty check`: clean

https://claude.ai/code/session_012vHU2a2iNmoiY2D4NMJ1QV

---
_Generated by [Claude Code](https://claude.ai/code/session_012vHU2a2iNmoiY2D4NMJ1QV)_