### PR TITLE
experiment: does Mermaid help an LLM reason over table relationships? (no)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-mermaid-joinpath-eval.md
+++ b/docs/superpowers/plans/2026-06-07-mermaid-joinpath-eval.md
@@ -1,0 +1,1565 @@
+# Mermaid Join-Path Eval — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone harness that measures whether rendering an (anonymized) Spider schema graph as XML vs. Mermaid vs. natural-language adjacency changes an LLM's join-path reconstruction accuracy.
+
+**Architecture:** A pure deterministic core (schema parsing, opaque anonymization, three renderers, edge grading) that is fully unit-tested offline, wrapped by I/O modules (Spider acquisition, OpenRouter client) and a budget-capped runner that writes one JSONL row per model call, plus a stats module (strata + paired McNemar + bootstrap CIs).
+
+**Tech Stack:** Python 3.12, `uv`, `sqlglot` (gold/predicted edge extraction + column qualification), `openai` SDK pointed at OpenRouter, `scipy` (McNemar), `pydantic`/dataclasses, `pytest`.
+
+Reference spec: `docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md`.
+
+---
+
+## File Structure
+
+```
+experiments/mermaid-joinpath-eval/
+  pyproject.toml         # standalone project (own venv)
+  .gitignore             # data/ results/ .venv/
+  README.md              # how to source the key and run
+  mje/
+    __init__.py
+    schema_graph.py      # Column, FKEdge, SchemaGraph; parse tables.json; gold-edge + gold-table extraction
+    anonymize.py         # deterministic opaque remap of graph + edge/table sets
+    renderers.py         # render_xml · render_mermaid · render_nl_adjacency (fixed ordering)
+    grade.py             # parse model output → edges; precision/recall/F1/exact/hallucinated
+    prompt.py            # build_messages(rendering, endpoint_tables)
+    data.py              # download Spider; build Item list (filter ≥2 joins, ambiguity flag)
+    model_client.py      # OpenRouter call + PRICING + cost()
+    runner.py            # orchestrate items × renderings × models; budget cap; results.jsonl
+    stats.py             # aggregate; McNemar; bootstrap CIs; summary table
+  tests/
+    fixtures/spider_mini/   # tiny tables.json + dev.json for offline tests
+    test_schema_graph.py
+    test_anonymize.py
+    test_renderers.py
+    test_grade.py
+    test_prompt.py
+    test_model_client.py
+    test_data.py
+    test_stats.py
+```
+
+**Core types (defined in Task 1, used everywhere — keep names exact):**
+- `Column(table: str, name: str, type: str)` — frozen dataclass.
+- `FKEdge(a: tuple[str, str], b: tuple[str, str])` — each side is `(table, column)`.
+- `SchemaGraph(db_id: str, tables: dict[str, list[Column]], fk_edges: list[FKEdge])`.
+- An **edge key** is `frozenset({(table, col), (table, col)})` — undirected, used for all set comparisons.
+- Helper `edge_key(a: tuple[str,str], b: tuple[str,str]) -> frozenset` lives in `schema_graph.py`.
+
+---
+
+## Task 0: Scaffold the standalone project
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/pyproject.toml`
+- Create: `experiments/mermaid-joinpath-eval/.gitignore`
+- Create: `experiments/mermaid-joinpath-eval/mje/__init__.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/__init__.py`
+
+- [ ] **Step 1: Create `pyproject.toml`**
+
+```toml
+[project]
+name = "mje"
+version = "0.1.0"
+description = "Mermaid vs text rendering for LLM join-path reasoning (anonymized Spider)"
+requires-python = ">=3.12"
+dependencies = [
+    "sqlglot>=25",
+    "openai>=1.40",
+    "requests>=2.31",
+    "scipy>=1.11",
+]
+
+[dependency-groups]
+dev = ["pytest>=8"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+- [ ] **Step 2: Create `.gitignore`**
+
+```gitignore
+.venv/
+data/
+results/
+__pycache__/
+*.pyc
+```
+
+- [ ] **Step 3: Create empty package markers**
+
+`mje/__init__.py` and `tests/__init__.py` are empty files.
+
+- [ ] **Step 4: Sync and verify the env builds**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv sync`
+Expected: resolves and installs sqlglot, openai, requests, scipy, pytest without error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/pyproject.toml experiments/mermaid-joinpath-eval/.gitignore experiments/mermaid-joinpath-eval/mje/__init__.py experiments/mermaid-joinpath-eval/tests/__init__.py
+git commit -m "chore(mje): scaffold standalone join-path eval project"
+```
+
+---
+
+## Task 1: `schema_graph.py` — types, tables.json parsing, gold extraction
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/schema_graph.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_schema_graph.py`
+- Create fixtures: `experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/tables.json`
+
+**Spider `tables.json` shape (per DB):** `table_names_original` (list), `column_names_original`
+(list of `[table_index, "colname"]`, with index 0 = `[-1, "*"]`), `column_types`, `foreign_keys`
+(list of `[col_index, col_index]` into `column_names_original`).
+
+- [ ] **Step 1: Create the test fixture `tests/fixtures/spider_mini/tables.json`**
+
+```json
+[
+  {
+    "db_id": "shop",
+    "table_names_original": ["customers", "orders", "line_items", "products"],
+    "column_names_original": [
+      [-1, "*"],
+      [0, "id"], [0, "name"],
+      [1, "id"], [1, "customer_id"],
+      [2, "id"], [2, "order_id"], [2, "product_id"],
+      [3, "id"], [3, "title"]
+    ],
+    "column_types": ["text", "number", "text", "number", "number", "number", "number", "number", "number", "text"],
+    "foreign_keys": [[4, 1], [6, 3], [7, 8]]
+  }
+]
+```
+
+This encodes: `orders.customer_id → customers.id`, `line_items.order_id → orders.id`,
+`line_items.product_id → products.id` (a 4-table chain with a branch).
+
+- [ ] **Step 2: Write the failing test `tests/test_schema_graph.py`**
+
+```python
+import json
+from pathlib import Path
+from mje.schema_graph import (
+    Column, FKEdge, SchemaGraph, edge_key,
+    parse_tables_json, extract_gold_edges, gold_tables,
+)
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _shop() -> SchemaGraph:
+    entry = json.loads(FIX.read_text())[0]
+    return parse_tables_json(entry)
+
+
+def test_parse_tables_json_builds_tables_and_columns():
+    g = _shop()
+    assert g.db_id == "shop"
+    assert set(g.tables) == {"customers", "orders", "line_items", "products"}
+    cols = {c.name for c in g.tables["orders"]}
+    assert cols == {"id", "customer_id"}
+    # the synthetic "*" column is dropped
+    assert all(c.name != "*" for t in g.tables.values() for c in t)
+
+
+def test_parse_tables_json_builds_fk_edges():
+    g = _shop()
+    keys = {edge_key(e.a, e.b) for e in g.fk_edges}
+    assert edge_key(("orders", "customer_id"), ("customers", "id")) in keys
+    assert edge_key(("line_items", "order_id"), ("orders", "id")) in keys
+    assert edge_key(("line_items", "product_id"), ("products", "id")) in keys
+    assert len(g.fk_edges) == 3
+
+
+def test_extract_gold_edges_resolves_aliases_and_where_joins():
+    g = _shop()
+    # explicit JOIN ... ON with aliases
+    q1 = ("SELECT T1.name FROM customers AS T1 JOIN orders AS T2 "
+          "ON T1.id = T2.customer_id")
+    e1 = extract_gold_edges(q1, g)
+    assert e1 == {edge_key(("customers", "id"), ("orders", "customer_id"))}
+
+    # comma-join with WHERE equality (Spider style), 3 tables = 2 join edges
+    q2 = ("SELECT c.name FROM customers c, orders o, line_items l "
+          "WHERE c.id = o.customer_id AND o.id = l.order_id")
+    e2 = extract_gold_edges(q2, g)
+    assert e2 == {
+        edge_key(("customers", "id"), ("orders", "customer_id")),
+        edge_key(("orders", "id"), ("line_items", "order_id")),
+    }
+
+
+def test_extract_gold_edges_qualifies_unqualified_columns():
+    g = _shop()
+    # unqualified join columns; resolvable via schema
+    q = "SELECT title FROM line_items JOIN products ON product_id = products.id"
+    e = extract_gold_edges(q, g)
+    assert e == {edge_key(("line_items", "product_id"), ("products", "id"))}
+
+
+def test_gold_tables_returns_from_join_tables():
+    g = _shop()
+    q = ("SELECT c.name FROM customers c JOIN orders o ON c.id = o.customer_id "
+         "JOIN line_items l ON o.id = l.order_id")
+    assert gold_tables(q, g) == {"customers", "orders", "line_items"}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_schema_graph.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.schema_graph'`.
+
+- [ ] **Step 4: Implement `mje/schema_graph.py`**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.optimizer.qualify import qualify
+
+
+@dataclass(frozen=True)
+class Column:
+    table: str
+    name: str
+    type: str
+
+
+@dataclass
+class FKEdge:
+    a: tuple[str, str]  # (table, column)
+    b: tuple[str, str]
+
+
+@dataclass
+class SchemaGraph:
+    db_id: str
+    tables: dict[str, list[Column]] = field(default_factory=dict)
+    fk_edges: list[FKEdge] = field(default_factory=list)
+
+
+def edge_key(a: tuple[str, str], b: tuple[str, str]) -> frozenset:
+    """Undirected key for a join edge, lowercased for stable comparison."""
+    return frozenset({(a[0].lower(), a[1].lower()), (b[0].lower(), b[1].lower())})
+
+
+def parse_tables_json(entry: dict) -> SchemaGraph:
+    table_names = entry["table_names_original"]
+    col_defs = entry["column_names_original"]      # [[t_idx, name], ...] ; index 0 is [-1,"*"]
+    col_types = entry["column_types"]
+
+    tables: dict[str, list[Column]] = {t: [] for t in table_names}
+    # column index -> (table, name); skip the synthetic "*" at index 0
+    col_ref: dict[int, tuple[str, str]] = {}
+    for idx, (t_idx, cname) in enumerate(col_defs):
+        if t_idx < 0:
+            continue
+        tname = table_names[t_idx]
+        ctype = col_types[idx] if idx < len(col_types) else "text"
+        tables[tname].append(Column(table=tname, name=cname, type=ctype))
+        col_ref[idx] = (tname, cname)
+
+    fk_edges: list[FKEdge] = []
+    for c1, c2 in entry.get("foreign_keys", []):
+        if c1 in col_ref and c2 in col_ref:
+            fk_edges.append(FKEdge(a=col_ref[c1], b=col_ref[c2]))
+
+    return SchemaGraph(db_id=entry["db_id"], tables=tables, fk_edges=fk_edges)
+
+
+def _schema_dict(graph: SchemaGraph) -> dict[str, dict[str, str]]:
+    """Schema mapping sqlglot's qualifier understands: {table: {col: type}}."""
+    return {
+        t: {c.name: (c.type or "text").upper() for c in cols}
+        for t, cols in graph.tables.items()
+    }
+
+
+def _qualified_ast(query: str, graph: SchemaGraph):
+    ast = sqlglot.parse_one(query, read="sqlite")
+    # qualify resolves aliases AND unqualified columns against the schema
+    return qualify(ast, schema=_schema_dict(graph), qualify_columns=True, validate_qualify_columns=False)
+
+
+def _table_of(col: exp.Column, ast) -> str | None:
+    """Resolve a (qualified) column's source table name from the qualified AST."""
+    tbl = col.table
+    if not tbl:
+        return None
+    # tbl is either a real table name or an alias; map alias -> table
+    for source in ast.find_all(exp.Table):
+        if (source.alias_or_name or "").lower() == tbl.lower():
+            return source.name  # underlying table name
+    return tbl
+
+
+def extract_gold_edges(query: str, graph: SchemaGraph) -> set[frozenset]:
+    """Return the set of undirected join edges (column == column across tables)."""
+    ast = _qualified_ast(query, graph)
+    edges: set[frozenset] = set()
+    for eq in ast.find_all(exp.EQ):
+        left, right = eq.left, eq.right
+        if isinstance(left, exp.Column) and isinstance(right, exp.Column):
+            lt, rt = _table_of(left, ast), _table_of(right, ast)
+            if lt and rt and lt.lower() != rt.lower():
+                edges.add(edge_key((lt, left.name), (rt, right.name)))
+    return edges
+
+
+def gold_tables(query: str, graph: SchemaGraph) -> set[str]:
+    ast = _qualified_ast(query, graph)
+    names = {t.name for t in ast.find_all(exp.Table)}
+    valid = {k.lower(): k for k in graph.tables}
+    return {valid[n.lower()] for n in names if n.lower() in valid}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_schema_graph.py -v`
+Expected: PASS (5 tests). If alias resolution fails on the comma-join case, confirm `qualify` ran with `read="sqlite"`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/schema_graph.py experiments/mermaid-joinpath-eval/tests/test_schema_graph.py experiments/mermaid-joinpath-eval/tests/fixtures
+git commit -m "feat(mje): schema graph parsing and gold join-edge extraction"
+```
+
+---
+
+## Task 2: `anonymize.py` — deterministic opaque remap
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/anonymize.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_anonymize.py`
+
+Mapping: tables in declared order → `t0, t1, ...`; columns within a table in declared order → `c0, c1, ...`.
+Same mapping rewrites the graph, the gold edge set, and the endpoint table list.
+
+- [ ] **Step 1: Write the failing test `tests/test_anonymize.py`**
+
+```python
+import json
+from pathlib import Path
+from mje.schema_graph import parse_tables_json, edge_key
+from mje.anonymize import anonymize, map_edges, map_tables
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _shop():
+    return parse_tables_json(json.loads(FIX.read_text())[0])
+
+
+def test_anonymize_renames_tables_and_columns_opaquely():
+    g = _shop()
+    ag, m = anonymize(g)
+    assert set(ag.tables) == {"t0", "t1", "t2", "t3"}
+    # no original token survives anywhere
+    blob = " ".join(
+        [t for t in ag.tables] + [c.name for cols in ag.tables.values() for c in cols]
+    )
+    for original in ["customers", "orders", "line_items", "products", "customer_id", "title"]:
+        assert original not in blob
+    # types are preserved
+    assert {c.type for c in ag.tables["t0"]} <= {"text", "number"}
+
+
+def test_mapping_is_consistent_across_graph_and_edges():
+    g = _shop()
+    ag, m = anonymize(g)
+    gold = {edge_key(("orders", "customer_id"), ("customers", "id"))}
+    mapped = map_edges(gold, m)
+    # the mapped edge must reference only tokens that exist in the anonymized graph
+    (pair,) = mapped
+    for (tname, cname) in pair:
+        assert tname in ag.tables
+        assert cname in {c.name for c in ag.tables[tname]}
+
+
+def test_map_tables():
+    g = _shop()
+    ag, m = anonymize(g)
+    assert map_tables({"customers", "line_items"}, m) == {
+        m.table["customers"], m.table["line_items"]
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_anonymize.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.anonymize'`.
+
+- [ ] **Step 3: Implement `mje/anonymize.py`**
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mje.schema_graph import Column, FKEdge, SchemaGraph, edge_key
+
+
+@dataclass
+class Mapping:
+    table: dict[str, str] = field(default_factory=dict)            # orig table -> t{i}
+    column: dict[tuple[str, str], str] = field(default_factory=dict)  # (orig table, orig col) -> c{j}
+
+
+def anonymize(graph: SchemaGraph) -> tuple[SchemaGraph, Mapping]:
+    m = Mapping()
+    new_tables: dict[str, list[Column]] = {}
+    for ti, (tname, cols) in enumerate(graph.tables.items()):
+        new_t = f"t{ti}"
+        m.table[tname] = new_t
+        new_cols: list[Column] = []
+        for cj, col in enumerate(cols):
+            new_c = f"c{cj}"
+            m.column[(tname, col.name)] = new_c
+            new_cols.append(Column(table=new_t, name=new_c, type=col.type))
+        new_tables[new_t] = new_cols
+
+    new_edges: list[FKEdge] = []
+    for e in graph.fk_edges:
+        a = (m.table[e.a[0]], m.column[(e.a[0], e.a[1])])
+        b = (m.table[e.b[0]], m.column[(e.b[0], e.b[1])])
+        new_edges.append(FKEdge(a=a, b=b))
+
+    return SchemaGraph(db_id=graph.db_id, tables=new_tables, fk_edges=new_edges), m
+
+
+def _map_pair(pair: tuple[str, str], m: Mapping) -> tuple[str, str]:
+    tname, cname = pair
+    return m.table[tname], m.column[(tname, cname)]
+
+
+def map_edges(edges: set[frozenset], m: Mapping) -> set[frozenset]:
+    out: set[frozenset] = set()
+    for e in edges:
+        (p1, p2) = tuple(e)
+        out.add(edge_key(_map_pair(p1, m), _map_pair(p2, m)))
+    return out
+
+
+def map_tables(tables: set[str], m: Mapping) -> set[str]:
+    return {m.table[t] for t in tables}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_anonymize.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/anonymize.py experiments/mermaid-joinpath-eval/tests/test_anonymize.py
+git commit -m "feat(mje): deterministic opaque-token anonymization"
+```
+
+---
+
+## Task 3: `renderers.py` — three information-equivalent renderings
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/renderers.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_renderers.py`
+
+All renderers take an **anonymized** `SchemaGraph`, use **fixed ordering** (tables by name, columns by
+declared order, edges sorted by their string form), and encode the same tables/columns/types/FK edges.
+
+- [ ] **Step 1: Write the failing test `tests/test_renderers.py`**
+
+```python
+import json
+from pathlib import Path
+from mje.schema_graph import parse_tables_json
+from mje.anonymize import anonymize
+from mje.renderers import render_xml, render_mermaid, render_nl_adjacency, RENDERERS
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _anon():
+    g = parse_tables_json(json.loads(FIX.read_text())[0])
+    ag, _ = anonymize(g)
+    return ag
+
+
+def test_all_renderers_mention_every_table():
+    ag = _anon()
+    for name, fn in RENDERERS.items():
+        out = fn(ag)
+        for t in ag.tables:
+            assert t in out, f"{name} dropped table {t}"
+
+
+def test_renderers_encode_every_fk_edge():
+    ag = _anon()
+    # each rendering must contain both endpoints of every edge near each other;
+    # we assert each edge's two columns both appear in the text
+    for name, fn in RENDERERS.items():
+        out = fn(ag)
+        for e in ag.fk_edges:
+            assert e.a[1] in out and e.b[1] in out
+
+
+def test_xml_is_wellformed_enough():
+    ag = _anon()
+    out = render_xml(ag)
+    assert out.count("<table") == len(ag.tables)
+    assert out.count("<rel ") == len(ag.fk_edges)
+
+
+def test_mermaid_has_header():
+    ag = _anon()
+    out = render_mermaid(ag)
+    assert out.strip().startswith("erDiagram")
+
+
+def test_deterministic_output():
+    ag = _anon()
+    for fn in RENDERERS.values():
+        assert fn(ag) == fn(ag)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_renderers.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.renderers'`.
+
+- [ ] **Step 3: Implement `mje/renderers.py`**
+
+```python
+from __future__ import annotations
+
+from mje.schema_graph import FKEdge, SchemaGraph
+
+
+def _sorted_tables(graph: SchemaGraph) -> list[str]:
+    return sorted(graph.tables)
+
+
+def _sorted_edges(graph: SchemaGraph) -> list[FKEdge]:
+    def key(e: FKEdge):
+        return tuple(sorted([f"{e.a[0]}.{e.a[1]}", f"{e.b[0]}.{e.b[1]}"]))
+    return sorted(graph.fk_edges, key=key)
+
+
+def render_xml(graph: SchemaGraph) -> str:
+    lines = ["<schema>"]
+    for t in _sorted_tables(graph):
+        cols = "".join(
+            f'<column name="{c.name}" type="{c.type}"/>' for c in graph.tables[t]
+        )
+        lines.append(f'  <table name="{t}">{cols}</table>')
+    lines.append("  <relationships>")
+    for e in _sorted_edges(graph):
+        lines.append(
+            f'    <rel from="{e.a[0]}.{e.a[1]}" to="{e.b[0]}.{e.b[1]}" type="many_to_one"/>'
+        )
+    lines.append("  </relationships>")
+    lines.append("</schema>")
+    return "\n".join(lines)
+
+
+def render_mermaid(graph: SchemaGraph) -> str:
+    lines = ["erDiagram"]
+    for t in _sorted_tables(graph):
+        body = "  ".join(f"{c.type} {c.name}" for c in graph.tables[t])
+        lines.append(f"  {t} {{ {body} }}")
+    for e in _sorted_edges(graph):
+        lines.append(f'  {e.a[0]} ||--o{{ {e.b[0]} : "{e.a[1]} = {e.b[1]}"')
+    return "\n".join(lines)
+
+
+def render_nl_adjacency(graph: SchemaGraph) -> str:
+    lines = []
+    for t in _sorted_tables(graph):
+        cols = ", ".join(f"{c.name} ({c.type})" for c in graph.tables[t])
+        lines.append(f"{t} has columns {cols}.")
+    for e in _sorted_edges(graph):
+        lines.append(
+            f"{e.a[0]} joins to {e.b[0]} via {e.a[0]}.{e.a[1]} = {e.b[0]}.{e.b[1]} (many_to_one)."
+        )
+    return "\n".join(lines)
+
+
+RENDERERS = {
+    "xml": render_xml,
+    "mermaid": render_mermaid,
+    "nl_adjacency": render_nl_adjacency,
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_renderers.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/renderers.py experiments/mermaid-joinpath-eval/tests/test_renderers.py
+git commit -m "feat(mje): three information-equivalent schema renderers"
+```
+
+---
+
+## Task 4: `grade.py` — parse model output and score edges
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/grade.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_grade.py`
+
+Model output is JSON-first (`["t0.c1 = t1.c0", ...]`); fall back to parsing as SQL via sqlglot.
+A predicted edge is **hallucinated** if its column pair is not an FK edge of the graph.
+
+- [ ] **Step 1: Write the failing test `tests/test_grade.py`**
+
+```python
+import json
+from pathlib import Path
+from mje.schema_graph import parse_tables_json, edge_key
+from mje.anonymize import anonymize
+from mje.grade import parse_pred_edges, score
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _anon():
+    g = parse_tables_json(json.loads(FIX.read_text())[0])
+    ag, _ = anonymize(g)
+    return ag
+
+
+def test_parse_json_array_of_conditions():
+    ag = _anon()
+    text = '```json\n["t1.c1 = t0.c0", "t2.c1 = t1.c0"]\n```'
+    edges = parse_pred_edges(text, ag)
+    assert edge_key(("t1", "c1"), ("t0", "c0")) in edges
+    assert edge_key(("t2", "c1"), ("t1", "c0")) in edges
+
+
+def test_parse_sql_fallback():
+    ag = _anon()
+    text = "SELECT * FROM t0 JOIN t1 ON t0.c0 = t1.c1"
+    edges = parse_pred_edges(text, ag)
+    assert edges == {edge_key(("t0", "c0"), ("t1", "c1"))}
+
+
+def test_score_perfect():
+    ag = _anon()
+    gold = {edge_key(("t0", "c0"), ("t1", "c1"))}
+    pred = {edge_key(("t1", "c1"), ("t0", "c0"))}  # order-insensitive
+    s = score(pred, gold, ag)
+    assert s["f1"] == 1.0 and s["exact"] is True and s["hallucinated"] == 0
+
+
+def test_score_partial_and_hallucination():
+    ag = _anon()
+    gold = {
+        edge_key(("t0", "c0"), ("t1", "c1")),
+        edge_key(("t1", "c0"), ("t2", "c1")),
+    }
+    # one correct, one invented edge that is not an FK in the graph
+    pred = {
+        edge_key(("t0", "c0"), ("t1", "c1")),
+        edge_key(("t0", "c1"), ("t3", "c0")),
+    }
+    s = score(pred, gold, ag)
+    assert s["precision"] == 0.5
+    assert s["recall"] == 0.5
+    assert round(s["f1"], 3) == 0.5
+    assert s["exact"] is False
+    assert s["hallucinated"] == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_grade.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.grade'`.
+
+- [ ] **Step 3: Implement `mje/grade.py`**
+
+```python
+from __future__ import annotations
+
+import json
+import re
+
+import sqlglot
+from sqlglot import exp
+
+from mje.schema_graph import SchemaGraph, edge_key
+
+_COND = re.compile(r"([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.([A-Za-z_]\w*)")
+
+
+def _fk_keys(graph: SchemaGraph) -> set[frozenset]:
+    return {edge_key(e.a, e.b) for e in graph.fk_edges}
+
+
+def _extract_json_block(text: str) -> list[str] | None:
+    # strip code fences, find the first JSON array
+    cleaned = re.sub(r"```[a-zA-Z]*", "", text).replace("```", "")
+    start = cleaned.find("[")
+    end = cleaned.rfind("]")
+    if start == -1 or end == -1 or end < start:
+        return None
+    try:
+        val = json.loads(cleaned[start : end + 1])
+        return [str(x) for x in val] if isinstance(val, list) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def parse_pred_edges(text: str, graph: SchemaGraph) -> set[frozenset]:
+    edges: set[frozenset] = set()
+
+    items = _extract_json_block(text)
+    if items is not None:
+        for cond in items:
+            mt = _COND.search(cond)
+            if mt:
+                t1, c1, t2, c2 = mt.groups()
+                edges.add(edge_key((t1, c1), (t2, c2)))
+        if edges:
+            return edges
+
+    # SQL fallback
+    try:
+        ast = sqlglot.parse_one(text, read="sqlite")
+        for eq in ast.find_all(exp.EQ):
+            l, r = eq.left, eq.right
+            if isinstance(l, exp.Column) and isinstance(r, exp.Column) and l.table and r.table:
+                edges.add(edge_key((l.table, l.name), (r.table, r.name)))
+    except Exception:
+        pass
+    return edges
+
+
+def score(pred: set[frozenset], gold: set[frozenset], graph: SchemaGraph) -> dict:
+    fk = _fk_keys(graph)
+    tp = len(pred & gold)
+    precision = tp / len(pred) if pred else 0.0
+    recall = tp / len(gold) if gold else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    hallucinated = len([e for e in pred if e not in fk])
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "exact": pred == gold,
+        "hallucinated": hallucinated,
+        "n_pred": len(pred),
+        "n_gold": len(gold),
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_grade.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/grade.py experiments/mermaid-joinpath-eval/tests/test_grade.py
+git commit -m "feat(mje): model-output edge parsing and scoring"
+```
+
+---
+
+## Task 5: `prompt.py` — single-shot reconstruction prompt
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/prompt.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_prompt.py`
+
+- [ ] **Step 1: Write the failing test `tests/test_prompt.py`**
+
+```python
+from mje.prompt import build_messages
+
+
+def test_build_messages_contains_rendering_and_tables():
+    msgs = build_messages("RENDERING_TEXT", ["t0", "t2", "t5"])
+    assert msgs[0]["role"] == "system"
+    assert msgs[1]["role"] == "user"
+    user = msgs[1]["content"]
+    assert "RENDERING_TEXT" in user
+    assert "t0" in user and "t2" in user and "t5" in user
+    assert "JSON" in user or "json" in user
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_prompt.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.prompt'`.
+
+- [ ] **Step 3: Implement `mje/prompt.py`**
+
+```python
+from __future__ import annotations
+
+SYSTEM = (
+    "You connect database tables. Given a schema and a set of tables, output ONLY the "
+    "JOIN conditions needed to connect those tables into one query. Use only columns that "
+    "appear in the schema. Respond with a JSON array of strings like "
+    '["ta.cx = tb.cy", ...] and nothing else.'
+)
+
+USER_TEMPLATE = (
+    "Schema:\n{rendering}\n\n"
+    "Connect these tables into a single joined query: {tables}.\n"
+    "Return the minimal set of join conditions as a JSON array of \"ta.cx = tb.cy\" strings."
+)
+
+
+def build_messages(rendering: str, endpoint_tables: list[str]) -> list[dict]:
+    tables = ", ".join(endpoint_tables)
+    return [
+        {"role": "system", "content": SYSTEM},
+        {"role": "user", "content": USER_TEMPLATE.format(rendering=rendering, tables=tables)},
+    ]
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_prompt.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/prompt.py experiments/mermaid-joinpath-eval/tests/test_prompt.py
+git commit -m "feat(mje): single-shot reconstruction prompt builder"
+```
+
+---
+
+## Task 6: `data.py` — Spider acquisition and Item building
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/data.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_data.py`
+- Create fixture: `experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/dev.json`
+
+`Item` carries everything the runner needs, already anonymized: the anon graph, anon gold edges, anon
+endpoint tables, join count, and an ambiguity flag. **Ambiguity proxy:** the connected component of the
+FK graph that spans the endpoint tables contains a cycle (edges ≥ nodes), meaning more than one path can
+connect them.
+
+- [ ] **Step 1: Create fixture `tests/fixtures/spider_mini/dev.json`**
+
+```json
+[
+  {"db_id": "shop", "question": "ignored",
+   "query": "SELECT T1.name FROM customers AS T1 JOIN orders AS T2 ON T1.id = T2.customer_id"},
+  {"db_id": "shop", "question": "ignored",
+   "query": "SELECT c.name FROM customers c, orders o, line_items l WHERE c.id = o.customer_id AND o.id = l.order_id"},
+  {"db_id": "shop", "question": "ignored",
+   "query": "SELECT name FROM customers"}
+]
+```
+
+- [ ] **Step 2: Write the failing test `tests/test_data.py`**
+
+```python
+from pathlib import Path
+from mje.data import build_items
+
+FIXDIR = Path(__file__).parent / "fixtures" / "spider_mini"
+
+
+def test_build_items_filters_by_min_joins_and_anonymizes():
+    items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=2)
+    # only the 2-join comma query qualifies (single-join and no-join dropped)
+    assert len(items) == 1
+    it = items[0]
+    assert it.n_joins == 2
+    # everything is anonymized: tables look like t{i}
+    assert all(t.startswith("t") for t in it.endpoint_tables)
+    for pair in it.gold_edges:
+        for (tname, cname) in pair:
+            assert tname in it.graph.tables
+            assert cname in {c.name for c in it.graph.tables[tname]}
+
+
+def test_min_joins_one_keeps_more():
+    items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=1)
+    assert len(items) == 2  # the no-join query is still dropped
+
+
+def test_ambiguity_flag_present():
+    items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=2)
+    assert isinstance(items[0].ambiguous, bool)
+    # the shop chain is acyclic over the used tables -> not ambiguous
+    assert items[0].ambiguous is False
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_data.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.data'`.
+
+- [ ] **Step 4: Implement `mje/data.py`**
+
+```python
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+from mje.anonymize import anonymize, map_edges, map_tables
+from mje.schema_graph import (
+    SchemaGraph, parse_tables_json, extract_gold_edges, gold_tables,
+)
+
+# Spider dev/tables JSON (HuggingFace mirror). If this 404s, download Spider manually and
+# pass --tables/--dev paths to the runner; see README.
+SPIDER_TABLES_URL = "https://huggingface.co/datasets/xlangai/spider/resolve/main/spider/tables.json"
+SPIDER_DEV_URL = "https://huggingface.co/datasets/xlangai/spider/resolve/main/spider/dev.json"
+
+
+@dataclass
+class Item:
+    item_id: str
+    db_id: str
+    query: str
+    graph: SchemaGraph              # anonymized
+    gold_edges: set[frozenset]     # anonymized
+    endpoint_tables: list[str]     # anonymized, sorted
+    n_joins: int
+    ambiguous: bool
+
+
+def download_spider(dest: Path) -> tuple[Path, Path]:
+    dest.mkdir(parents=True, exist_ok=True)
+    tables_p, dev_p = dest / "tables.json", dest / "dev.json"
+    for url, p in [(SPIDER_TABLES_URL, tables_p), (SPIDER_DEV_URL, dev_p)]:
+        if not p.exists():
+            r = requests.get(url, timeout=60)
+            r.raise_for_status()
+            p.write_bytes(r.content)
+    return tables_p, dev_p
+
+
+def _ambiguous(raw_graph: SchemaGraph, used_tables: set[str]) -> bool:
+    # connected component spanning used_tables; cycle (edges >= nodes) => multiple paths
+    adj: dict[str, set[str]] = {t: set() for t in raw_graph.tables}
+    edge_set: set[frozenset] = set()
+    for e in raw_graph.fk_edges:
+        ta, tb = e.a[0], e.b[0]
+        if ta != tb:
+            adj[ta].add(tb)
+            adj[tb].add(ta)
+            edge_set.add(frozenset({ta, tb}))
+    # BFS the component containing any used table
+    seen: set[str] = set()
+    stack = list(used_tables)
+    while stack:
+        n = stack.pop()
+        if n in seen:
+            continue
+        seen.add(n)
+        stack.extend(adj[n] - seen)
+    comp_edges = [e for e in edge_set if set(e) <= seen]
+    return len(comp_edges) >= len(seen) and len(seen) > 0
+
+
+def build_items(tables_path: Path, dev_path: Path, min_joins: int = 2,
+                limit: int | None = None) -> list[Item]:
+    tables = {e["db_id"]: parse_tables_json(e) for e in json.loads(Path(tables_path).read_text())}
+    dev = json.loads(Path(dev_path).read_text())
+
+    items: list[Item] = []
+    for i, ex in enumerate(dev):
+        db_id, query = ex["db_id"], ex["query"]
+        graph = tables.get(db_id)
+        if graph is None:
+            continue
+        try:
+            gold = extract_gold_edges(query, graph)
+            used = gold_tables(query, graph)
+        except Exception:
+            continue
+        if len(gold) < min_joins:
+            continue
+        ambiguous = _ambiguous(graph, used)
+        anon_graph, m = anonymize(graph)
+        items.append(Item(
+            item_id=f"{db_id}-{i}",
+            db_id=db_id,
+            query=query,
+            graph=anon_graph,
+            gold_edges=map_edges(gold, m),
+            endpoint_tables=sorted(map_tables(used, m)),
+            n_joins=len(gold),
+            ambiguous=ambiguous,
+        ))
+        if limit and len(items) >= limit:
+            break
+    return items
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_data.py -v`
+Expected: PASS (3 tests). Network is not touched (tests use fixtures; `download_spider` is exercised later by the runner smoke step).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/data.py experiments/mermaid-joinpath-eval/tests/test_data.py experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/dev.json
+git commit -m "feat(mje): Spider acquisition and anonymized Item building"
+```
+
+---
+
+## Task 7: `model_client.py` — OpenRouter client + cost accounting
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/model_client.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_model_client.py`
+
+Tested against a **fake transport** (no live calls). `PRICING` is per-token (USD).
+
+- [ ] **Step 1: Write the failing test `tests/test_model_client.py`**
+
+```python
+from mje.model_client import ModelClient, cost, PRICING
+
+
+class _FakeResp:
+    def __init__(self):
+        self.choices = [type("C", (), {"message": type("M", (), {"content": '["t0.c0 = t1.c1"]'})})]
+        self.usage = type("U", (), {"prompt_tokens": 1000, "completion_tokens": 50})
+
+
+class _FakeChat:
+    def __init__(self): self.completions = self
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        return _FakeResp()
+
+
+class _FakeClient:
+    def __init__(self): self.chat = _FakeChat()
+
+
+def test_cost_uses_pricing_table():
+    c = cost("anthropic/claude-sonnet-4.6", 1_000_000, 1_000_000)
+    p = PRICING["anthropic/claude-sonnet-4.6"]
+    assert round(c, 6) == round(p["in"] + p["out"], 6)
+
+
+def test_client_call_returns_text_and_usage():
+    mc = ModelClient(api_key="x", client=_FakeClient())
+    text, in_tok, out_tok = mc.call("anthropic/claude-sonnet-4.6",
+                                    [{"role": "user", "content": "hi"}], max_tokens=256)
+    assert text == '["t0.c0 = t1.c1"]'
+    assert in_tok == 1000 and out_tok == 50
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_model_client.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.model_client'`.
+
+- [ ] **Step 3: Implement `mje/model_client.py`**
+
+```python
+from __future__ import annotations
+
+import os
+import time
+
+# USD per token. Source: OpenRouter pricing (per-Mtok / 1e6).
+PRICING = {
+    "anthropic/claude-sonnet-4.6": {"in": 3.0e-6, "out": 15.0e-6},
+    "deepseek/deepseek-v4-flash": {"in": 0.0983e-6, "out": 0.1966e-6},
+}
+
+
+def cost(model: str, in_tok: int, out_tok: int) -> float:
+    p = PRICING[model]
+    return in_tok * p["in"] + out_tok * p["out"]
+
+
+class ModelClient:
+    def __init__(self, api_key: str | None = None, base_url: str = "https://openrouter.ai/api/v1",
+                 client=None):
+        if client is not None:
+            self._client = client
+        else:
+            from openai import OpenAI
+            key = api_key or os.environ["OPENROUTER_API_KEY"]
+            self._client = OpenAI(api_key=key, base_url=base_url)
+
+    def call(self, model: str, messages: list[dict], max_tokens: int = 256,
+             retries: int = 3) -> tuple[str, int, int]:
+        last = None
+        for attempt in range(retries):
+            try:
+                resp = self._client.chat.completions.create(
+                    model=model, messages=messages, temperature=0, max_tokens=max_tokens,
+                )
+                text = resp.choices[0].message.content or ""
+                u = resp.usage
+                return text, int(u.prompt_tokens), int(u.completion_tokens)
+            except Exception as e:  # transient network/rate errors
+                last = e
+                time.sleep(2 ** attempt)
+        raise RuntimeError(f"model call failed after {retries} retries: {last}")
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_model_client.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/model_client.py experiments/mermaid-joinpath-eval/tests/test_model_client.py
+git commit -m "feat(mje): OpenRouter client with cost accounting (mock-tested)"
+```
+
+---
+
+## Task 8: `runner.py` — orchestration with budget cap
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/runner.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_runner.py`
+
+The runner is a CLI. The **scoring loop is extracted into `run_eval(items, models, client, ...)`** so it can be
+unit-tested with a fake client; `main()` only parses args, loads data, and calls it. Budget cap aborts before a
+call whose projected cost would exceed `max_spend`.
+
+- [ ] **Step 1: Write the failing test `tests/test_runner.py`**
+
+```python
+import json
+from pathlib import Path
+from mje.schema_graph import parse_tables_json
+from mje.anonymize import anonymize, map_edges, map_tables
+from mje.schema_graph import extract_gold_edges, gold_tables
+from mje.data import Item
+from mje.runner import run_eval
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini"
+
+
+class _FakeClient:
+    """Always returns the gold edges as a JSON array -> perfect score."""
+    def __init__(self, items): self._by_id = {it.item_id: it for it in items}
+    def call(self, model, messages, max_tokens=256, retries=3):
+        # recover which item by matching endpoint tables present in the prompt
+        user = messages[1]["content"]
+        for it in self._by_id.values():
+            if all(t in user for t in it.endpoint_tables):
+                conds = [f"{tuple(e)[0][0]}.{tuple(e)[0][1]} = {tuple(e)[1][0]}.{tuple(e)[1][1]}"
+                         for e in it.gold_edges]
+                return json.dumps(conds), 100, 20
+        return "[]", 100, 20
+
+
+def _one_item():
+    g = parse_tables_json(json.loads((FIX / "tables.json").read_text())[0])
+    q = ("SELECT c.name FROM customers c, orders o, line_items l "
+         "WHERE c.id = o.customer_id AND o.id = l.order_id")
+    gold = extract_gold_edges(q, g)
+    used = gold_tables(q, g)
+    ag, m = anonymize(g)
+    return Item("shop-1", "shop", q, ag, map_edges(gold, m), sorted(map_tables(used, m)), 2, False)
+
+
+def test_run_eval_scores_all_renderings(tmp_path):
+    items = [_one_item()]
+    client = _FakeClient(items)
+    out = tmp_path / "results.jsonl"
+    rows = run_eval(items, models=["anthropic/claude-sonnet-4.6"], client=client,
+                    out_path=out, max_spend=1.0)
+    # 1 item x 3 renderings x 1 model = 3 rows, all perfect
+    assert len(rows) == 3
+    assert all(r["f1"] == 1.0 and r["exact"] for r in rows)
+    assert {r["rendering"] for r in rows} == {"xml", "mermaid", "nl_adjacency"}
+    assert out.exists() and len(out.read_text().strip().splitlines()) == 3
+
+
+def test_budget_cap_aborts(tmp_path):
+    items = [_one_item()]
+    client = _FakeClient(items)
+    rows = run_eval(items, models=["anthropic/claude-sonnet-4.6"], client=client,
+                    out_path=tmp_path / "r.jsonl", max_spend=0.0)
+    assert rows == []  # cap of 0 stops before any call
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_runner.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.runner'`.
+
+- [ ] **Step 3: Implement `mje/runner.py`**
+
+```python
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from mje.data import Item, build_items, download_spider
+from mje.grade import parse_pred_edges, score
+from mje.model_client import ModelClient, cost
+from mje.prompt import build_messages
+from mje.renderers import RENDERERS
+
+
+def run_eval(items: list[Item], models: list[str], client, out_path: Path,
+             max_spend: float = 2.0, max_tokens: int = 256, samples: int = 1) -> list[dict]:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    spent = 0.0
+    EST_PER_CALL = 0.02  # conservative pre-call guess (USD) for the budget gate
+
+    with out_path.open("w") as fh:
+        for it in items:
+            for rname, rfn in RENDERERS.items():
+                rendering = rfn(it.graph)
+                messages = build_messages(rendering, it.endpoint_tables)
+                for model in models:
+                    for s in range(samples):
+                        if spent + EST_PER_CALL > max_spend:
+                            print(f"[budget] stopping: spent ${spent:.3f}, cap ${max_spend:.2f}")
+                            return rows
+                        text, in_tok, out_tok = client.call(model, messages, max_tokens=max_tokens)
+                        spent += cost(model, in_tok, out_tok)
+                        pred = parse_pred_edges(text, it.graph)
+                        sc = score(pred, it.gold_edges, it.graph)
+                        row = {
+                            "item_id": it.item_id, "db_id": it.db_id, "n_joins": it.n_joins,
+                            "ambiguous": it.ambiguous, "model": model, "rendering": rname,
+                            "sample": s, "in_tok": in_tok, "out_tok": out_tok,
+                            "cost_usd": cost(model, in_tok, out_tok),
+                            **sc,
+                            "gold_edges": [sorted(tuple(p) for p in e) for e in it.gold_edges],
+                            "pred_edges": [sorted(tuple(p) for p in e) for e in pred],
+                        }
+                        fh.write(json.dumps(row) + "\n")
+                        fh.flush()
+                        rows.append(row)
+    print(f"[done] {len(rows)} calls, spent ${spent:.3f}")
+    return rows
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-dir", default="data")
+    ap.add_argument("--tables", default=None, help="override tables.json path")
+    ap.add_argument("--dev", default=None, help="override dev.json path")
+    ap.add_argument("--out", default="results/results.jsonl")
+    ap.add_argument("--min-joins", type=int, default=2)
+    ap.add_argument("--n", type=int, default=45, help="max items (hardest strata first)")
+    ap.add_argument("--samples", type=int, default=1)
+    ap.add_argument("--max-spend", type=float, default=2.0)
+    ap.add_argument("--models", nargs="+",
+                    default=["anthropic/claude-sonnet-4.6", "deepseek/deepseek-v4-flash"])
+    args = ap.parse_args()
+
+    if args.tables and args.dev:
+        tables_p, dev_p = Path(args.tables), Path(args.dev)
+    else:
+        tables_p, dev_p = download_spider(Path(args.data_dir))
+
+    items = build_items(tables_p, dev_p, min_joins=args.min_joins)
+    # hardest first, then cap to N
+    items.sort(key=lambda it: it.n_joins, reverse=True)
+    items = items[: args.n]
+
+    # rough pre-run estimate
+    est = len(items) * len(RENDERERS) * len(args.models) * args.samples * 0.02
+    print(f"[plan] {len(items)} items x {len(RENDERERS)} renderings x {len(args.models)} models "
+          f"x {args.samples} sample(s); rough est ${est:.2f}; cap ${args.max_spend:.2f}")
+
+    client = ModelClient()
+    run_eval(items, models=args.models, client=client, out_path=Path(args.out),
+             max_spend=args.max_spend, samples=args.samples)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_runner.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/runner.py experiments/mermaid-joinpath-eval/tests/test_runner.py
+git commit -m "feat(mje): budget-capped eval runner"
+```
+
+---
+
+## Task 9: `stats.py` — aggregation, McNemar, bootstrap CIs
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/mje/stats.py`
+- Create: `experiments/mermaid-joinpath-eval/tests/test_stats.py`
+
+- [ ] **Step 1: Write the failing test `tests/test_stats.py`**
+
+```python
+from mje.stats import aggregate, mcnemar_pairs
+
+
+def _rows():
+    # two items, two renderings, one model; mermaid beats xml on item 2
+    return [
+        {"item_id": "a", "model": "M", "rendering": "xml", "n_joins": 2, "ambiguous": False, "f1": 1.0, "exact": True},
+        {"item_id": "a", "model": "M", "rendering": "mermaid", "n_joins": 2, "ambiguous": False, "f1": 1.0, "exact": True},
+        {"item_id": "b", "model": "M", "rendering": "xml", "n_joins": 3, "ambiguous": False, "f1": 0.0, "exact": False},
+        {"item_id": "b", "model": "M", "rendering": "mermaid", "n_joins": 3, "ambiguous": False, "f1": 1.0, "exact": True},
+    ]
+
+
+def test_aggregate_means_by_group():
+    agg = aggregate(_rows())
+    # mean f1 for (M, xml) over 2 items = 0.5 ; (M, mermaid) = 1.0
+    xml = [r for r in agg if r["model"] == "M" and r["rendering"] == "xml" and r["stratum"] == "all"][0]
+    mer = [r for r in agg if r["model"] == "M" and r["rendering"] == "mermaid" and r["stratum"] == "all"][0]
+    assert xml["mean_f1"] == 0.5
+    assert mer["mean_f1"] == 1.0
+
+
+def test_mcnemar_returns_pvalue():
+    res = mcnemar_pairs(_rows(), model="M")
+    pair = [r for r in res if {r["a"], r["b"]} == {"xml", "mermaid"}][0]
+    assert "p_value" in pair and 0.0 <= pair["p_value"] <= 1.0
+    # discordant: item b (xml wrong, mermaid right) -> b01/b10 captured
+    assert pair["b_a_wrong_b_right"] == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_stats.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'mje.stats'`.
+
+- [ ] **Step 3: Implement `mje/stats.py`**
+
+```python
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from itertools import combinations
+from pathlib import Path
+
+from scipy.stats import binomtest
+
+
+def _stratum(n_joins: int) -> str:
+    return "2" if n_joins == 2 else "3" if n_joins == 3 else "4+"
+
+
+def aggregate(rows: list[dict]) -> list[dict]:
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for r in rows:
+        for st in ("all", _stratum(r["n_joins"])):
+            groups[(r["model"], r["rendering"], st)].append(r)
+    out = []
+    for (model, rendering, st), rs in sorted(groups.items()):
+        n = len(rs)
+        out.append({
+            "model": model, "rendering": rendering, "stratum": st, "n": n,
+            "mean_f1": sum(r["f1"] for r in rs) / n,
+            "exact_rate": sum(1 for r in rs if r["exact"]) / n,
+        })
+    return out
+
+
+def mcnemar_pairs(rows: list[dict], model: str) -> list[dict]:
+    # index exact-match by (item_id, rendering) for this model
+    by: dict[tuple, bool] = {}
+    renderings: set[str] = set()
+    items: set[str] = set()
+    for r in rows:
+        if r["model"] != model:
+            continue
+        by[(r["item_id"], r["rendering"])] = bool(r["exact"])
+        renderings.add(r["rendering"])
+        items.add(r["item_id"])
+
+    results = []
+    for a, b in combinations(sorted(renderings), 2):
+        b01 = b10 = 0  # a wrong/b right ; a right/b wrong
+        for it in items:
+            if (it, a) in by and (it, b) in by:
+                ra, rb = by[(it, a)], by[(it, b)]
+                if not ra and rb:
+                    b01 += 1
+                elif ra and not rb:
+                    b10 += 1
+        n = b01 + b10
+        p = binomtest(b01, n, 0.5).pvalue if n > 0 else 1.0
+        results.append({
+            "model": model, "a": a, "b": b,
+            "b_a_wrong_b_right": b01, "b_a_right_b_wrong": b10, "p_value": p,
+        })
+    return results
+
+
+def load_rows(path: Path) -> list[dict]:
+    return [json.loads(l) for l in Path(path).read_text().splitlines() if l.strip()]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results", default="results/results.jsonl")
+    args = ap.parse_args()
+    rows = load_rows(Path(args.results))
+
+    print("\n=== mean F1 / exact-rate by model × rendering × stratum ===")
+    for r in aggregate(rows):
+        print(f"{r['model']:<32} {r['rendering']:<13} {r['stratum']:<4} "
+              f"n={r['n']:<4} F1={r['mean_f1']:.3f} exact={r['exact_rate']:.3f}")
+
+    print("\n=== paired McNemar (exact-match) ===")
+    for model in sorted({r["model"] for r in rows}):
+        for res in mcnemar_pairs(rows, model):
+            print(f"{model:<32} {res['a']} vs {res['b']}: "
+                  f"disc {res['b_a_wrong_b_right']}/{res['b_a_right_b_wrong']} "
+                  f"p={res['p_value']:.4f}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest tests/test_stats.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/mje/stats.py experiments/mermaid-joinpath-eval/tests/test_stats.py
+git commit -m "feat(mje): aggregation and paired McNemar stats"
+```
+
+---
+
+## Task 10: README + full-suite green + live smoke (gated)
+
+**Files:**
+- Create: `experiments/mermaid-joinpath-eval/README.md`
+
+- [ ] **Step 1: Write `README.md`**
+
+````markdown
+# Mermaid Join-Path Eval
+
+Measures whether rendering an (anonymized) Spider schema as XML / Mermaid / NL-adjacency changes an
+LLM's join-path reconstruction accuracy. See the design spec under
+`docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md`.
+
+## Setup
+```bash
+cd experiments/mermaid-joinpath-eval
+uv sync
+uv run pytest -q          # all deterministic units, offline
+```
+
+## Run the pilot (spends OpenRouter credit)
+The key is read from `OPENROUTER_API_KEY`; source it from the lens project (never commit it):
+```bash
+set -a; . /Users/qingye/Documents/lens/.env; set +a
+uv run python -m mje.runner --n 45 --max-spend 2.00
+uv run python -m mje.stats --results results/results.jsonl
+```
+
+Flags: `--n` items (hardest strata first), `--samples`, `--models`, `--min-joins`, `--max-spend`,
+and `--tables/--dev` to point at a manual Spider download if the HF mirror URL is unavailable.
+
+## Notes
+- Schemas are opaque-token anonymized to defeat training contamination (Spider predates the model cutoff).
+- Grading is static (no DB execution): gold join edges come from gold SQL via sqlglot.
+````
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd experiments/mermaid-joinpath-eval && uv run pytest -q`
+Expected: all tests PASS (schema_graph, anonymize, renderers, grade, prompt, data, model_client, runner, stats).
+
+- [ ] **Step 3: Live smoke test (gated — needs key + ~$0.05)**
+
+Run:
+```bash
+cd experiments/mermaid-joinpath-eval
+set -a; . /Users/qingye/Documents/lens/.env; set +a
+uv run python -m mje.runner --n 2 --max-spend 0.10 --models anthropic/claude-sonnet-4.6
+uv run python -m mje.stats --results results/results.jsonl
+```
+Expected: downloads Spider, runs 2 items × 3 renderings × 1 model = 6 calls, prints a stats table,
+and `results/results.jsonl` has 6 rows. If the HF URL 404s, follow the README manual-download note.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add experiments/mermaid-joinpath-eval/README.md
+git commit -m "docs(mje): usage README and smoke instructions"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4 task (opaque + reconstruction) → Tasks 2, 5, 6 (endpoint tables = gold tables, JSON join-conditions).
+- §5 datasets (Spider dev, ≥2 joins, strata, ambiguity flag) → Task 6 (`build_items`, `_ambiguous`) + Task 9 (`_stratum`).
+- §6 anonymization (opaque, bijective, types kept) → Task 2.
+- §7 renderings (3, fixed ordering, info-equivalent) → Task 3.
+- §8 prompt (single-shot, JSON output) → Task 5.
+- §9 models (Sonnet 4.6 + DeepSeek V4 Flash, OpenRouter) → Task 7 (`PRICING`) + Task 8 (`--models`).
+- §10 grading (edge F1, exact, hallucinated; JSON-first w/ SQL fallback) → Task 4.
+- §11 stats (strata, paired McNemar, summary) → Task 9. *Bootstrap CIs are printed as group means;
+  full bootstrap intervals deferred — noted as acceptable for the pilot table.*
+- §13 budget (pre-call estimate, `--max-spend` cap, defaults N≈45) → Task 8.
+- §14 testing (every deterministic unit + mock client) → Tasks 1–9.
+
+**Placeholder scan:** No "TBD"/"add error handling"/"similar to" placeholders; every code step is complete.
+
+**Type consistency:** `Item` fields (`graph`, `gold_edges`, `endpoint_tables`, `n_joins`, `ambiguous`)
+are produced in Task 6 and consumed identically in Task 8. `score()` keys (`f1`, `exact`, `hallucinated`,
+`precision`, `recall`) defined in Task 4 are used unchanged in Tasks 8–9. `edge_key`/`frozenset` edge
+representation is consistent across Tasks 1–9. `RENDERERS` dict (Task 3) is the single source of renderings
+in Tasks 8 and 10.
+
+**One deliberate deviation from the spec:** §11 mentions bootstrap CIs; the plan ships group means + McNemar
+and defers true bootstrap intervals (YAGNI for a ~45-item pilot). Flagged here rather than silently dropped.
+````

--- a/docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md
+++ b/docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md
@@ -1,0 +1,226 @@
+# Design: Mermaid vs. text rendering for join-path reasoning — anonymized-Spider eval
+
+- **Date:** 2026-06-07
+- **Status:** Approved design (pre-implementation)
+- **Owner:** Qing
+- **Topic:** Does rendering a table-relationship graph as Mermaid (vs. XML vs. natural-language adjacency) help an LLM pick the correct multi-table join path?
+
+## 1. Motivation
+
+`agentic-data-contracts` exposes table relationships to an agent so it can compose correct multi-table SQL
+(see `semantic/base.py::Relationship`, `build_relationship_index`, `find_join_path`, and the XML rendering in
+`core/prompt.py::ClaudePromptRenderer._render_relationships`). A proposal (inspired by TencentDB-Agent-Memory's
+use of Mermaid as a memory carrier) is to render the relationship graph as **Mermaid** instead of XML, on the
+theory that graph notation is more traversable for the model.
+
+Before investing in a renderer + integration, we want **empirical evidence** that the rendering format changes
+join-path-selection accuracy. This experiment provides that evidence cheaply and standalone, decoupled from the
+library.
+
+## 2. Background (priors from the literature)
+
+These findings shape the design (full citations in the conversation that produced this spec):
+
+- **Talk like a Graph (ICLR 2024):** graph *encoding format* swings LLM accuracy by up to 60%, but the effect is
+  task- and structure-dependent and concentrates on multi-hop/path tasks. → Stratify by hop count.
+- **Graph Linearization (2024):** *node ordering* (degree/PageRank, locality) matters as much as surface syntax;
+  on path tasks gains were modest (+8.5 pts shortest-path on an 8B model). → Control ordering; expect small effects.
+- **Lost in Serialization (2025):** LLMs are *non-invariant* to edge reordering / relabeling; large non-fine-tuned
+  models are far more robust. → Treat robustness as a metric; expect weaker models to be more format-sensitive.
+- **Death of Schema Linking? (2024):** strong models barely benefit from representation help on small schemas;
+  sensitivity *decreases* with capability. → Expect a possible null on Sonnet; expect larger effect on DeepSeek.
+- **Contamination:** Sonnet 4.6 training-data cutoff is **Jan 2026**; Spider (2018) is contaminated. Contamination
+  biases a paired rendering A/B toward a **false null** (model recalls the answer regardless of rendering). →
+  Anonymization is mandatory to force the model to read the provided graph.
+
+## 3. Hypotheses
+
+- **H1 (primary):** For a fixed model, join-path reconstruction accuracy differs across renderings
+  (XML vs. Mermaid vs. NL-adjacency), with the difference growing as the number of required join edges increases.
+- **H2 (secondary, capability gradient):** Any rendering effect is larger for the weaker model
+  (DeepSeek V4 Flash) than for the stronger model (Sonnet 4.6).
+- **Null result is a valid, valuable outcome:** "no significant difference" tells us Mermaid is not worth the
+  integration effort for this regime.
+
+## 4. Task definition — opaque tokens + join-path reconstruction
+
+Opaque-token anonymization is incompatible with Spider's natural-language questions (the model cannot map
+"singer's age" to `t1.c3`). We therefore use a **join-path reconstruction** task, which isolates graph traversal
+with zero name-semantics leakage and maps directly onto the shortest-path literature, grounded on real Spider
+topologies.
+
+**Per item:**
+
+- Input to the model: a rendered schema graph (one of three renderings) of the anonymized database, plus a
+  specified set of **endpoint tables** = the set of tables referenced in the gold query's `FROM`/`JOIN` clauses.
+- Required output: the **join conditions** needed to connect those endpoint tables (including any intermediate
+  bridge tables), as a JSON list of `t_a.c_i = t_b.c_j` equalities. Raw SQL is also accepted (parsed as fallback).
+- Gold: the set of join edges in the human-authored gold SQL.
+
+The model must (a) find which tables to traverse and (b) choose the correct join columns — the core of join-path
+selection. The NL question is intentionally **not** provided; it is a confound for this measurement.
+
+## 5. Datasets
+
+- **Source:** Spider **dev** set — `tables.json` (schemas + `foreign_keys`, `column_names`, `table_names`) and
+  `dev.json` (gold SQL). No SQLite databases and no query execution are required; all grading is static.
+- **Acquisition:** download `tables.json` and `dev.json` (HuggingFace mirror or direct); robust to source with a
+  documented fallback. Cached locally under `data/` (gitignored).
+- **Filtering:** keep items whose gold SQL has **≥ 2 join edges** (counted via `sqlglot`). Stratify into
+  **2 / 3 / 4+** join-edge buckets.
+- **Ambiguity flag:** for each item, compute whether more than one valid path connects the endpoint tables in the
+  FK graph; mark such items `ambiguous=true` (exact-match is unreliable there; F1 remains primary).
+
+## 6. Anonymization (opaque tokens)
+
+- Deterministic per-database remap: tables `table_names[i] → t{i}`, columns `column_names[j] → c{j}`
+  (column ids are global in Spider's `tables.json`; map to `t{table}.c{local_index}` for readability).
+- Applied consistently to: the schema graph, the gold SQL (identifier rewrite via `sqlglot`), and the endpoint
+  table list. The mapping is bijective and round-trippable.
+- No semantic hints survive (no type-named columns, no `_id` suffixes). Column data **types** are retained
+  (e.g., `number`, `text`) since they carry no entity semantics but are realistic schema content.
+
+## 7. Renderings (same anonymized graph, three surfaces)
+
+All three encode identical information (tables, columns+types, FK edges, cardinality where known). Node/edge
+**ordering is fixed and identical** across renderings (tables by index, edges sorted lexicographically) to avoid
+confounding ordering with format.
+
+**XML** (mirrors the library's current `_render_relationships` style):
+```xml
+<schema>
+  <table name="t1"><column name="c0" type="number"/><column name="c1" type="text"/></table>
+  ...
+  <relationships>
+    <rel from="t1.c0" to="t3.c2" type="many_to_one"/>
+  </relationships>
+</schema>
+```
+
+**Mermaid** (topology-first; attributes via edge labels):
+```mermaid
+erDiagram
+  t1 { number c0  text c1 }
+  t3 { number c2 }
+  t1 ||--o{ t3 : "c0 = c2"
+```
+(We will pilot both `erDiagram` and a lighter `graph LR` flowchart form; default `erDiagram`.)
+
+**NL-adjacency** (verbose adjacency list — the format KG-prompting work found competitive):
+```
+t1 has columns c0 (number), c1 (text).
+t1 joins to t3 via t1.c0 = t3.c2 (many_to_one).
+```
+
+## 8. Prompt template (single-shot)
+
+System: "You connect database tables. Given a schema and a set of tables, output only the JOIN conditions needed
+to connect them, as a JSON array of strings like \"ta.cx = tb.cy\". Use only columns present in the schema."
+
+User: `<rendering>` + "Connect these tables into a single joined query: [t1, t3, t7]. Return the minimal set of
+join conditions as a JSON array."
+
+- `thinking` disabled / no extended reasoning (cost control + the task is short).
+- Output parsed as JSON array; fallback: parse as SQL via `sqlglot` and extract equality join predicates.
+
+## 9. Models
+
+| Role | OpenRouter slug | Pricing (in/out per Mtok) |
+|---|---|---|
+| Strong (target) | `anthropic/claude-sonnet-4.6` | $3.00 / $15.00 |
+| Weak (gradient) | `deepseek/deepseek-v4-flash` | $0.098 / $0.197 |
+
+Accessed via OpenRouter's OpenAI-compatible endpoint. Key read from `OPENROUTER_API_KEY` in the environment
+(sourced from `/Users/qingye/Documents/lens/.env`); **never copied into this repo or committed**.
+
+## 10. Grading & metrics
+
+- A join edge is the unordered pair `{ta.cx, tb.cy}`. Gold edges = equality join predicates in gold SQL
+  (`ON` and `WHERE`), extracted with `sqlglot`. Self-joins handled via alias-aware comparison.
+- **Per item, per (model × rendering):**
+  - **Edge F1** (primary) — precision/recall over the undirected edge set.
+  - **Exact-match** (secondary) — model edge set == gold edge set (skipped/flagged for `ambiguous` items).
+  - **Hallucinated-edge rate** — fraction of output edges not present in the FK graph at all.
+- Persist one row per call to `results/results.jsonl`:
+  `{item_id, db_id, n_joins, ambiguous, model, rendering, gold_edges, pred_edges, f1, exact, hallucinated, in_tok, out_tok, cost_usd}`.
+
+## 11. Statistics
+
+- Report mean F1 and exact-match per **(model × rendering × stratum 2/3/4+)** with bootstrap 95% CIs.
+- **Paired McNemar** on exact-match between rendering pairs (XML↔Mermaid, XML↔NL, Mermaid↔NL), per model, since
+  every item is seen under all renderings.
+- Note effect sizes and whether they clear the CI; explicitly report null results.
+- (Robustness check deferred — see §15.)
+
+## 12. Architecture
+
+Standalone, decoupled from the library. New directory:
+
+```
+experiments/mermaid-joinpath-eval/
+  pyproject.toml         # deps: openai, sqlglot, requests, scipy, pydantic, pytest
+  data.py                # acquire + parse tables.json/dev.json; filter by join count; ambiguity flag
+  schema_graph.py        # SchemaGraph model; gold join-edge extraction via sqlglot
+  anonymize.py           # deterministic opaque remap of graph + gold SQL (bijective)
+  renderers.py           # render_xml() · render_mermaid() · render_nl_adjacency()
+  prompt.py              # build_prompt(rendering, endpoint_tables)
+  model_client.py        # OpenRouter call (OpenAI-compatible), retries, token+cost accounting
+  grade.py               # parse model output → edges; F1 / exact / hallucinated vs gold
+  runner.py              # orchestrate items × renderings × models; budget cap; write results.jsonl
+  stats.py               # strata, McNemar, bootstrap CIs; summary table
+  tests/                 # TDD for every deterministic unit; model_client via mock
+  data/  results/        # gitignored
+  README.md              # how to source the key and run
+```
+
+Each module has one purpose and a small interface; deterministic modules (`schema_graph`, `anonymize`,
+`renderers`, `grade`) are pure and independently testable.
+
+## 13. Budget controls (hard requirement)
+
+Current OpenRouter balance ≈ **$2.37**. Therefore:
+
+- `runner.py` token-counts every rendered prompt and **prints a total cost estimate before any API call**.
+- `--max-spend` cap (default **$2.00**) aborts the run mid-stream if projected/actual spend exceeds it.
+- Defaults sized to fit: **N ≈ 45 items × 3 renderings × 2 models × 1 sample**
+  (Sonnet ≈ $1.3–1.7; DeepSeek negligible). Hard-filtered to the hardest strata first (prefer 3+ joins).
+- `--n`, `--samples`, `--models`, `--renderings` configurable to scale up after a top-up.
+
+## 14. Testing strategy (TDD)
+
+Verifiable here without an API key or budget:
+
+- `anonymize`: bijective round-trip; gold SQL rewritten consistently with the graph; no semantic tokens leak.
+- `schema_graph`: gold join-edge extraction on hand-written SQL (incl. self-join, `WHERE`-style joins) → known edges.
+- `grade`: hand cases for F1 (partial credit), exact-match, hallucinated edges, alias handling.
+- `renderers`: each emits parseable output and is information-equivalent (same edge set recoverable).
+- `model_client`: exercised against a **mock** transport (no live calls in tests).
+
+The only step not verifiable here is the live OpenRouter call; it runs behind a single documented command.
+
+## 15. Out of scope / future work
+
+- **Realistic NL-question arm** (requires plausible-novel naming, not opaque) — a separate study if reconstruction
+  shows a signal.
+- **External-validity arms:** Termite (genuinely uncontaminated, tiny) as a sanity check; SQaLe (large, `num_joins`
+  metadata) anonymized for scale — both deferred until the primary anonymized-Spider result is in.
+- **Order-invariance robustness test** (shuffle edge order / relabel, measure output stability) — deferred;
+  hooks left in `renderers` (fixed ordering today) to add a shuffled condition later.
+- **Library integration** of a Mermaid renderer — only if the experiment justifies it.
+
+## 16. Risks & mitigations
+
+- **Ceiling effect / null on Sonnet:** likely per the schema-linking literature; mitigated by including DeepSeek
+  (H2) and by targeting the hardest strata. A true null is an accepted outcome.
+- **Multi-path ambiguity:** flagged per item; F1 is primary, exact-match skipped on ambiguous items.
+- **Output parse failures:** JSON-first with sqlglot SQL fallback; unparseable → scored as zero and counted
+  separately so parse failures don't masquerade as reasoning failures.
+- **Budget overrun:** hard `--max-spend` cap + pre-call estimate.
+- **Mermaid dialect variance:** pilot both `erDiagram` and `graph LR`; pick the better-parsed default.
+
+## 17. Success criteria for the experiment
+
+The experiment succeeds (regardless of which way it points) when it produces, within budget:
+a per-(model × rendering × stratum) F1/exact-match table with CIs and paired McNemar p-values, on anonymized
+(decontaminated) real Spider schemas, with parse-failure and ambiguity rates reported — enough to decide
+**go / no-go** on building a Mermaid renderer for the library.

--- a/experiments/mermaid-joinpath-eval/.gitignore
+++ b/experiments/mermaid-joinpath-eval/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+data/
+results/
+__pycache__/
+*.pyc

--- a/experiments/mermaid-joinpath-eval/FINDINGS.md
+++ b/experiments/mermaid-joinpath-eval/FINDINGS.md
@@ -71,10 +71,12 @@ trending worse." **Keep the existing XML relationship rendering** (`core/prompt.
 If Mermaid is ever desired for human readability, **fully table-qualify the join columns in edge labels** —
 that recovers most of the penalty.
 
-This matches the literature: for capable models, schema-representation format has small and shrinking effects
-(see "Death of Schema Linking?"), and rigid structured formats do not beat plain verbalization for reasoning
-(see KG-prompting work). The original Mermaid-as-memory idea (TencentDB-Agent-Memory) works for *episodic*
-task memory via compression + drill-down; it does not transfer to *semantic* relationship memory here.
+This is consistent with the literature: capable models are increasingly robust to schema *presentation*.
+"Death of Schema Linking?" (Maamari et al., 2024, arXiv:2408.07702) shows modern models barely need the
+schema filtered down to relevant tables — they generate fine over the full schema; our result adds, one level
+down, that they are also largely indifferent to the rendering *notation* once join columns are unambiguous.
+The original Mermaid-as-memory idea (TencentDB-Agent-Memory) works for *episodic* task memory via
+compression + drill-down; it does not transfer to *semantic* relationship memory here.
 
 ## Methodological catches (why smoke-first mattered)
 

--- a/experiments/mermaid-joinpath-eval/FINDINGS.md
+++ b/experiments/mermaid-joinpath-eval/FINDINGS.md
@@ -1,0 +1,116 @@
+# Findings: Does Mermaid help an LLM reason over table relationships?
+
+**Date:** 2026-06-07
+**Question:** Is rendering a table-relationship graph as **Mermaid** a more effective "memory carrier"
+for an LLM than the library's current **XML**, or than plain **natural-language adjacency** — measured by
+join-path reconstruction accuracy?
+**Short answer:** **No.** Mermaid is at best tied-within-noise and at worst significantly *worse*.
+XML and NL-adjacency are equivalent and best. **Do not switch the library's relationship rendering to Mermaid.**
+
+Design spec: `docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md`.
+Plan: `docs/superpowers/plans/2026-06-07-mermaid-joinpath-eval.md`.
+
+## Method
+
+- **Task (join-path reconstruction):** given a rendered schema graph + the set of endpoint tables a gold
+  query touches, the model outputs the JOIN conditions connecting them. Grading is static (no DB execution):
+  the model's join-edge set is compared to the gold query's join edges (extracted with `sqlglot`).
+- **Renderings (information-equivalent, fixed ordering):** `xml`, `mermaid` (erDiagram), `nl_adjacency`,
+  and later `mermaid_qualified` (erDiagram with fully table-qualified edge labels).
+- **Contamination control:** every schema is **opaque-token anonymized** (`orders→t1`, `customer_id→t1.c3`)
+  so the model cannot recall memorized gold SQL — essential because both datasets predate the models'
+  training cutoff. Anonymization is the decontamination strategy (no public benchmark post-dates the cutoff).
+- **Models (via OpenRouter):** `anthropic/claude-sonnet-4.6` (strong) and `deepseek/deepseek-v4-flash`
+  (weaker, reasoning) — to test whether any effect grows as capability drops.
+- **Metrics:** undirected join-edge **F1** (primary) and **exact-match** of the edge set; paired **McNemar**
+  on exact-match across renderings (every item seen under all renderings).
+- **Datasets:** Spider dev (1034 items) and BIRD mini-dev (500 items), both filtered to gold SQL with
+  ≥2 join edges. "clean" numbers below exclude rows truncated by the output-token cap.
+
+## Headline results
+
+### Spider (shallow joins) — uninformative ceiling
+Both models reconstruct 2–3-join paths near-perfectly on Spider regardless of rendering (F1 ≈ 0.96–1.00,
+no significant differences). Spider dev is too join-shallow to separate the renderings: of 1034 dev queries,
+only 65 have 2 join edges, 6 have 3, and **none** have 4+. This motivated moving to BIRD.
+
+### BIRD mini-dev (deeper joins, larger schemas) — powered result, n=98
+Mean F1 / exact-match, clean (truncated rows excluded):
+
+| Rendering | Sonnet 4.6 F1 / exact | DeepSeek V4 Flash F1 / exact |
+|---|---|---|
+| **xml** | **0.852 / 0.755** | **0.865 / 0.750** |
+| **nl_adjacency** | **0.852 / 0.755** | 0.843 / 0.694 |
+| mermaid_qualified | 0.827 / 0.694 | 0.848 / 0.684 |
+| mermaid (raw) | 0.804 / 0.653 | 0.820 / 0.635 |
+
+Paired McNemar (exact-match), discordant counts as (a-wrong/b-right : a-right/b-wrong):
+
+| Comparison | Sonnet 4.6 | DeepSeek V4 Flash |
+|---|---|---|
+| xml vs nl_adjacency | 0 / 0, p=1.000 (tied) | 0 / 4, p=0.125 (n.s.) |
+| mermaid (raw) vs xml | 12 / 2, **p=0.013** | 11 / 0, **p=0.001** |
+| mermaid_qualified vs xml | 7 / 1, p=0.070 (n.s., trend) | 6 / 1, p=0.125 (n.s.) |
+| mermaid (raw) vs mermaid_qualified | 5 / 1, p=0.219 | 9 / 3, p=0.146 |
+
+**Reading:**
+1. **Raw Mermaid is significantly worse than XML** on both models (p=0.013 / 0.001).
+2. **About half that deficit was a renderer-design flaw**, not the notation: my `mermaid` edge label was
+   `"c0 = c2"` (unqualified) vs `t1.c0 = t3.c2` in XML/NL. The `mermaid_qualified` variant (qualified labels)
+   recovers roughly half the gap and is **no longer significantly worse than XML** (p=0.07 / 0.125).
+3. **A residual deficit remains** even with qualified labels — both Mermaid variants are numerically below
+   XML/NL on both models. The erDiagram notation appears marginally harder for the model than flat XML/NL,
+   but the effect is small and not statistically significant once labels are fair.
+4. **XML and NL-adjacency are tied and best.** The library's current XML rendering is already optimal here.
+
+## Conclusion / recommendation
+
+**Mermaid is not a better memory carrier for table relationships.** No Mermaid variant beat XML on either
+model; raw Mermaid was significantly worse, and fully-qualified Mermaid only caught up to "tied within noise,
+trending worse." **Keep the existing XML relationship rendering** (`core/prompt.py::_render_relationships`).
+If Mermaid is ever desired for human readability, **fully table-qualify the join columns in edge labels** —
+that recovers most of the penalty.
+
+This matches the literature: for capable models, schema-representation format has small and shrinking effects
+(see "Death of Schema Linking?"), and rigid structured formats do not beat plain verbalization for reasoning
+(see KG-prompting work). The original Mermaid-as-memory idea (TencentDB-Agent-Memory) works for *episodic*
+task memory via compression + drill-down; it does not transfer to *semantic* relationship memory here.
+
+## Methodological catches (why smoke-first mattered)
+
+- **Reasoning-token truncation:** DeepSeek V4 Flash is a reasoning model; with the initial `max_tokens=256`,
+  hidden reasoning consumed the whole budget and answers came back empty/truncated. The *first* smoke showed a
+  dramatic but **entirely artifactual** "XML collapses" effect. Fix: `max_tokens=4096` + log `raw`/`truncated`.
+- **Case-normalization bug:** all-lowercase test fixtures hid a `KeyError` between `edge_key` (lowercases) and
+  the anonymization map (original case); caught only by running on real Spider data.
+- **Fair-Mermaid confound:** the first BIRD result (Mermaid significantly worse) was partly my under-qualified
+  edge labels — isolated by the `mermaid_qualified` arm.
+
+## Limitations
+
+- Join depth is modest even in BIRD mini-dev (84×2-edge, 14×3-edge, 2×4-edge); the discriminating 4+ regime is
+  tiny. The full BIRD dev (1534 items) would add more deep cases.
+- Single sample per item at temperature 0 (deterministic); no within-item variance estimate.
+- The task gives the model the endpoint tables, so it tests join-*column* selection + bridge-finding, not
+  table discovery. A harder formulation might surface larger rendering effects.
+- Two models only; both fairly capable. A much weaker model might show bigger format sensitivity.
+
+## Reproduction
+
+```bash
+cd experiments/mermaid-joinpath-eval && uv sync && uv run pytest -q
+set -a; . /Users/qingye/Documents/lens/.env; set +a   # OPENROUTER_API_KEY
+
+# BIRD pilot (xml, mermaid, nl_adjacency), both models, ~$1.0
+uv run python -m mje.runner --dataset bird --n 98 --out results/bird_full.jsonl \
+  --models anthropic/claude-sonnet-4.6 deepseek/deepseek-v4-flash
+
+# Fair-Mermaid arm (qualified labels), ~$0.3
+uv run python -m mje.runner --dataset bird --n 98 --renderings mermaid_qualified \
+  --out results/bird_mermaidq.jsonl \
+  --models anthropic/claude-sonnet-4.6 deepseek/deepseek-v4-flash
+
+uv run python -m mje.stats --results results/bird_full.jsonl
+```
+
+Total OpenRouter spend for the full study (smokes + Spider + BIRD + fair-Mermaid): ≈ **$1.6**.

--- a/experiments/mermaid-joinpath-eval/FINDINGS.md
+++ b/experiments/mermaid-joinpath-eval/FINDINGS.md
@@ -1,14 +1,19 @@
 # Findings: Does Mermaid help an LLM reason over table relationships?
 
-**Date:** 2026-06-07
+**Date:** 2026-06-07 (revised 2026-06-15 after code review)
 **Question:** Is rendering a table-relationship graph as **Mermaid** a more effective "memory carrier"
 for an LLM than the library's current **XML**, or than plain **natural-language adjacency** — measured by
 join-path reconstruction accuracy?
-**Short answer:** **No.** Mermaid is at best tied-within-noise and at worst significantly *worse*.
-XML and NL-adjacency are equivalent and best. **Do not switch the library's relationship rendering to Mermaid.**
+**Short answer:** **No — keep XML.** But the evidence is subtler than the first cut suggested, and a code
+review corrected an overstatement. Mermaid is **not better** than XML on any subset. Its *aggregate* deficit
+is **statistically significant but confounded**: it is confined entirely to cyclic-schema items where static
+exact-match is unreliable (the model can pick a *valid alternate* join path that grading marks wrong). On the
+subset where the metric is trustworthy, all four renderings are **tied**, with Mermaid marginally highest.
+**Recommendation stands: do not switch the library's relationship rendering to Mermaid** — XML never loses and
+most reliably reproduces the canonical/gold join path, which is what a governance library wants.
 
-Design spec: `docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md`.
-Plan: `docs/superpowers/plans/2026-06-07-mermaid-joinpath-eval.md`.
+Design spec: `../../docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md` (repo root, not this dir).
+Plan: `../../docs/superpowers/plans/2026-06-07-mermaid-joinpath-eval.md`.
 
 ## Method
 
@@ -16,16 +21,22 @@ Plan: `docs/superpowers/plans/2026-06-07-mermaid-joinpath-eval.md`.
   query touches, the model outputs the JOIN conditions connecting them. Grading is static (no DB execution):
   the model's join-edge set is compared to the gold query's join edges (extracted with `sqlglot`).
 - **Renderings (information-equivalent, fixed ordering):** `xml`, `mermaid` (erDiagram), `nl_adjacency`,
-  and later `mermaid_qualified` (erDiagram with fully table-qualified edge labels).
+  and `mermaid_qualified` (erDiagram with fully table-qualified edge labels).
 - **Contamination control:** every schema is **opaque-token anonymized** (`orders→t1`, `customer_id→t1.c3`)
   so the model cannot recall memorized gold SQL — essential because both datasets predate the models'
   training cutoff. Anonymization is the decontamination strategy (no public benchmark post-dates the cutoff).
 - **Models (via OpenRouter):** `anthropic/claude-sonnet-4.6` (strong) and `deepseek/deepseek-v4-flash`
   (weaker, reasoning) — to test whether any effect grows as capability drops.
 - **Metrics:** undirected join-edge **F1** (primary) and **exact-match** of the edge set; paired **McNemar**
-  on exact-match across renderings (every item seen under all renderings).
+  on exact-match across renderings (every item seen under all renderings). Parse-failure rate (empty
+  prediction) and output-token truncation rate are tracked per rendering so neither can masquerade as a
+  reasoning effect, and so an *asymmetric* rate across renderings is detectable.
 - **Datasets:** Spider dev (1034 items) and BIRD mini-dev (500 items), both filtered to gold SQL with
-  ≥2 join edges. "clean" numbers below exclude rows truncated by the output-token cap.
+  ≥2 join edges. "clean" numbers below exclude rows truncated by the output-token cap (`--exclude-truncated`).
+- **Ambiguity flag:** an item is flagged `ambiguous` if the schema's FK graph contains a cycle (a proxy for
+  "more than one plausible join path may exist"). **Caveat:** this is a whole-schema proxy, not a property of
+  the specific query path, and in this BIRD sample it correlates with *easier* items (see below). It is used
+  to stratify results, because exact-match is least reliable exactly where alternate valid paths exist.
 
 ## Headline results
 
@@ -34,8 +45,9 @@ Both models reconstruct 2–3-join paths near-perfectly on Spider regardless of 
 no significant differences). Spider dev is too join-shallow to separate the renderings: of 1034 dev queries,
 only 65 have 2 join edges, 6 have 3, and **none** have 4+. This motivated moving to BIRD.
 
-### BIRD mini-dev (deeper joins, larger schemas) — powered result, n=98
-Mean F1 / exact-match, clean (truncated rows excluded):
+### BIRD mini-dev (deeper joins, larger schemas) — n=98, clean (truncated rows excluded)
+
+**Aggregate** mean F1 / exact-match:
 
 | Rendering | Sonnet 4.6 F1 / exact | DeepSeek V4 Flash F1 / exact |
 |---|---|---|
@@ -44,32 +56,59 @@ Mean F1 / exact-match, clean (truncated rows excluded):
 | mermaid_qualified | 0.827 / 0.694 | 0.848 / 0.684 |
 | mermaid (raw) | 0.804 / 0.653 | 0.820 / 0.635 |
 
-Paired McNemar (exact-match), discordant counts as (a-wrong/b-right : a-right/b-wrong):
+Taken alone this says "Mermaid worse." **But the aggregate is Simpson-fragile.** Splitting by the ambiguity
+flag flips the story:
 
-| Comparison | Sonnet 4.6 | DeepSeek V4 Flash |
+**Mean F1 by ambiguity subset:**
+
+| Rendering | Sonnet — unambig (n=41) | Sonnet — ambig (n=57) | DeepSeek — unambig (n≈40) | DeepSeek — ambig (n≈57) |
+|---|---|---|---|---|
+| xml | 0.707 | **0.956** | 0.748 | **0.946** |
+| nl_adjacency | 0.707 | **0.956** | 0.725 | 0.928 |
+| mermaid_qualified | 0.732 | 0.895 | 0.748 | 0.921 |
+| mermaid (raw) | **0.756** | 0.838 | **0.769** | 0.856 |
+
+On the **unambiguous** subset (metric reliable), Mermaid is *marginally highest*. On the **ambiguous** subset
+(metric unreliable), XML/NL are highest and Mermaid lowest. The aggregate is dominated by the 57 ambiguous
+items, so XML "wins" overall — but only on the items where the metric is least trustworthy.
+
+**Paired McNemar (exact-match), xml vs mermaid (raw), by subset** — direction shown as
+`xml-right/mermaid-wrong : mermaid-right/xml-wrong`:
+
+| Subset | Sonnet 4.6 | DeepSeek V4 Flash |
 |---|---|---|
-| xml vs nl_adjacency | 0 / 0, p=1.000 (tied) | 0 / 4, p=0.125 (n.s.) |
-| mermaid (raw) vs xml | 12 / 2, **p=0.013** | 11 / 0, **p=0.001** |
-| mermaid_qualified vs xml | 7 / 1, p=0.070 (n.s., trend) | 6 / 1, p=0.125 (n.s.) |
-| mermaid (raw) vs mermaid_qualified | 5 / 1, p=0.219 | 9 / 3, p=0.146 |
+| all items | 12 / 2, **p=0.013** | 11 / 0, **p=0.001** |
+| **unambiguous (metric reliable)** | 0 / 1, **p=1.000 (tied)** | 0 / 0, **p=1.000 (tied)** |
+| ambiguous (metric unreliable) | 12 / 1, p=0.003 | 11 / 0, p=0.001 |
 
-**Reading:**
-1. **Raw Mermaid is significantly worse than XML** on both models (p=0.013 / 0.001).
-2. **About half that deficit was a renderer-design flaw**, not the notation: my `mermaid` edge label was
-   `"c0 = c2"` (unqualified) vs `t1.c0 = t3.c2` in XML/NL. The `mermaid_qualified` variant (qualified labels)
-   recovers roughly half the gap and is **no longer significantly worse than XML** (p=0.07 / 0.125).
-3. **A residual deficit remains** even with qualified labels — both Mermaid variants are numerically below
-   XML/NL on both models. The erDiagram notation appears marginally harder for the model than flat XML/NL,
-   but the effect is small and not statistically significant once labels are fair.
-4. **XML and NL-adjacency are tied and best.** The library's current XML rendering is already optimal here.
+**Every drop of statistical significance comes from the ambiguous subset.** On the reliable subset the two are
+exactly tied. The same holds for `mermaid_qualified` (always between `mermaid` and `xml`; never significantly
+worse than XML on any subset) and for `xml` vs `nl_adjacency` (tied throughout).
+
+**Parse-failure and truncation are NOT the driver.** Empty-prediction rates are low and rendering-symmetric
+(≤1 item difference between mermaid and xml on each model; e.g. Sonnet xml 2.0% vs mermaid 3.1%). DeepSeek's
+xml and raw-mermaid had the *same* truncation count (2 each), so truncation cannot explain the gap. This
+robustness check is now reproducible via `stats.py` (it was applied manually in the first writeup but not
+shipped in code — the review caught that).
 
 ## Conclusion / recommendation
 
-**Mermaid is not a better memory carrier for table relationships.** No Mermaid variant beat XML on either
-model; raw Mermaid was significantly worse, and fully-qualified Mermaid only caught up to "tied within noise,
-trending worse." **Keep the existing XML relationship rendering** (`core/prompt.py::_render_relationships`).
-If Mermaid is ever desired for human readability, **fully table-qualify the join columns in edge labels** —
-that recovers most of the penalty.
+**Mermaid is not a better memory carrier for table relationships, and there is no subset on which it reliably
+beats XML.** The honest, review-corrected reading:
+
+1. **No rendering is reliably better; differences are small and subset-dependent.**
+2. **The aggregate "Mermaid significantly worse" result is confined to cyclic-schema items and is confounded.**
+   On those items the model may output a *valid alternate* join path that static exact-match marks wrong; the
+   grader cannot distinguish "wrong" from "valid-but-not-the-gold-path" without execution-based equivalence
+   checking. Two non-exclusive explanations (Mermaid genuinely guides to the canonical path less well when
+   multiple paths exist, vs. a pure scoring artifact) cannot be separated here.
+3. **On the metric-reliable (acyclic) subset, all renderings are statistically tied**, with Mermaid marginally
+   highest in mean F1 — so there is *no* evidence Mermaid is worse there.
+4. **Keep the existing XML relationship rendering** (`core/prompt.py::_render_relationships`). It is never
+   significantly worse than anything, and it most reliably reproduces the canonical/gold join path — exactly
+   what a governance library wants (predictable, auditable joins). Switching to Mermaid carries downside risk
+   on cyclic schemas with no demonstrated upside. If Mermaid is ever desired for human readability, **fully
+   table-qualify the join columns in edge labels** (`mermaid_qualified`) — it recovers most of the gap.
 
 This is consistent with the literature: capable models are increasingly robust to schema *presentation*.
 "Death of Schema Linking?" (Maamari et al., 2024, arXiv:2408.07702) shows modern models barely need the
@@ -78,30 +117,43 @@ down, that they are also largely indifferent to the rendering *notation* once jo
 The original Mermaid-as-memory idea (TencentDB-Agent-Memory) works for *episodic* task memory via
 compression + drill-down; it does not transfer to *semantic* relationship memory here.
 
-## Methodological catches (why smoke-first mattered)
+## Methodological catches (why smoke-first and code-review mattered)
 
 - **Reasoning-token truncation:** DeepSeek V4 Flash is a reasoning model; with the initial `max_tokens=256`,
   hidden reasoning consumed the whole budget and answers came back empty/truncated. The *first* smoke showed a
   dramatic but **entirely artifactual** "XML collapses" effect. Fix: `max_tokens=4096` + log `raw`/`truncated`.
 - **Case-normalization bug:** all-lowercase test fixtures hid a `KeyError` between `edge_key` (lowercases) and
   the anonymization map (original case); caught only by running on real Spider data.
-- **Fair-Mermaid confound:** the first BIRD result (Mermaid significantly worse) was partly my under-qualified
-  edge labels — isolated by the `mermaid_qualified` arm.
+- **Fair-Mermaid confound:** the first BIRD result (Mermaid significantly worse) was partly under-qualified
+  edge labels — isolated by the `mermaid_qualified` arm, which recovered ~half the aggregate gap.
+- **Ambiguity confound (found in code review):** the "Mermaid significantly worse" headline was driven
+  entirely by cyclic-schema items where exact-match is unreliable. The design had called for excluding/flagging
+  ambiguous items but `stats.py` never did; stratifying revealed the effect vanishes on the reliable subset.
+  This downgraded the claim from "significantly worse" to "not better; aggregate deficit is confounded."
 
 ## Limitations
 
+- **The `ambiguous` proxy is whole-schema (FK-graph cycle), not query-path-specific**, and in this sample it
+  correlates with *easier* items (ambig F1 ≈ 0.95 vs unambig ≈ 0.71) — likely because cyclic schemas here tend
+  to connect endpoint tables more directly. So "ambiguous" really means "schema has a cycle," a noisy stand-in
+  for join-path ambiguity. The robust takeaway does not depend on its exact semantics: the significant effect
+  is concentrated in one subset and absent in the complement.
+- **Static grading cannot credit valid alternate join paths.** Execution/equivalence-based grading would be
+  needed to determine whether Mermaid's divergent edges on cyclic schemas are wrong or valid-but-alternate.
 - Join depth is modest even in BIRD mini-dev (84×2-edge, 14×3-edge, 2×4-edge); the discriminating 4+ regime is
   tiny. The full BIRD dev (1534 items) would add more deep cases.
-- Single sample per item at temperature 0 (deterministic); no within-item variance estimate.
+- Single sample per item at temperature 0 (deterministic); no within-item variance estimate; no bootstrap CIs.
+- Six rendering-pair McNemar tests × 2 models × strata; no family-wise correction applied. The strongest
+  result (p=0.001) survives Bonferroni; the borderline ones (p≈0.07, 0.13) are already reported as n.s.
 - The task gives the model the endpoint tables, so it tests join-*column* selection + bridge-finding, not
   table discovery. A harder formulation might surface larger rendering effects.
-- Two models only; both fairly capable. A much weaker model might show bigger format sensitivity.
+- Two models only; both fairly capable.
 
 ## Reproduction
 
 ```bash
 cd experiments/mermaid-joinpath-eval && uv sync && uv run pytest -q
-set -a; . /Users/qingye/Documents/lens/.env; set +a   # OPENROUTER_API_KEY
+set -a; . "$LENS_ENV_FILE"; set +a   # provides OPENROUTER_API_KEY (keep the key out of this repo)
 
 # BIRD pilot (xml, mermaid, nl_adjacency), both models, ~$1.0
 uv run python -m mje.runner --dataset bird --n 98 --out results/bird_full.jsonl \
@@ -112,7 +164,13 @@ uv run python -m mje.runner --dataset bird --n 98 --renderings mermaid_qualified
   --out results/bird_mermaidq.jsonl \
   --models anthropic/claude-sonnet-4.6 deepseek/deepseek-v4-flash
 
-uv run python -m mje.stats --results results/bird_full.jsonl
+# Combine the two arms, then the stratified + clean stats (reproduces the tables above)
+cat results/bird_full.jsonl results/bird_mermaidq.jsonl > results/_bird_combined.jsonl
+uv run python -m mje.stats --results results/_bird_combined.jsonl --exclude-truncated
 ```
+
+`stats.py` prints mean F1 / exact / parse-fail / truncation by model × rendering × {all, join-depth, ambig,
+unambig}, then paired McNemar for items = all / unambig / ambig. The `unambig` block is the metric-reliable
+one; that is where the renderings are tied.
 
 Total OpenRouter spend for the full study (smokes + Spider + BIRD + fair-Mermaid): ≈ **$1.6**.

--- a/experiments/mermaid-joinpath-eval/README.md
+++ b/experiments/mermaid-joinpath-eval/README.md
@@ -12,15 +12,19 @@ uv run pytest -q          # all deterministic units, offline
 ```
 
 ## Run the pilot (spends OpenRouter credit)
-The key is read from `OPENROUTER_API_KEY`; source it from the lens project (never commit it):
+The key is read from `OPENROUTER_API_KEY`; source it from a `.env` that lives **outside** this repo
+(never commit it). Point `LENS_ENV_FILE` at that file:
 ```bash
-set -a; . /Users/qingye/Documents/lens/.env; set +a
+set -a; . "$LENS_ENV_FILE"; set +a   # the .env stays outside the repo
 uv run python -m mje.runner --n 45 --max-spend 2.00
-uv run python -m mje.stats --results results/results.jsonl
+uv run python -m mje.stats --results results/results.jsonl --exclude-truncated
 ```
 
 Flags: `--n` items (hardest strata first), `--samples`, `--models`, `--min-joins`, `--max-spend`,
-and `--tables/--dev` to point at a manual Spider download if the HF mirror URL is unavailable.
+`--max-tokens` (keep high for reasoning models), `--renderings` (subset), and `--tables/--dev` to
+point at a manual Spider download if the mirror URL is unavailable.
+`stats.py` stratifies by join depth and by the ambiguity (cyclic-schema) proxy, and `--exclude-truncated`
+drops output-token-truncated rows; see `FINDINGS.md` for why the ambiguity split matters.
 
 ## Notes
 - Schemas are opaque-token anonymized to defeat training contamination (Spider predates the model cutoff).

--- a/experiments/mermaid-joinpath-eval/README.md
+++ b/experiments/mermaid-joinpath-eval/README.md
@@ -1,0 +1,32 @@
+# Mermaid Join-Path Eval
+
+Measures whether rendering an (anonymized) Spider schema as XML / Mermaid / NL-adjacency changes an
+LLM's join-path reconstruction accuracy. See the design spec under
+`docs/superpowers/specs/2026-06-07-mermaid-joinpath-eval-design.md`.
+
+## Setup
+```bash
+cd experiments/mermaid-joinpath-eval
+uv sync
+uv run pytest -q          # all deterministic units, offline
+```
+
+## Run the pilot (spends OpenRouter credit)
+The key is read from `OPENROUTER_API_KEY`; source it from the lens project (never commit it):
+```bash
+set -a; . /Users/qingye/Documents/lens/.env; set +a
+uv run python -m mje.runner --n 45 --max-spend 2.00
+uv run python -m mje.stats --results results/results.jsonl
+```
+
+Flags: `--n` items (hardest strata first), `--samples`, `--models`, `--min-joins`, `--max-spend`,
+and `--tables/--dev` to point at a manual Spider download if the HF mirror URL is unavailable.
+
+## Notes
+- Schemas are opaque-token anonymized to defeat training contamination (Spider predates the model cutoff).
+- Grading is static (no DB execution): gold join edges come from gold SQL via sqlglot.
+- Data source: the full Spider dev set (166 DBs / 1034 items) is fetched from the `taoyds/spider`
+  GitHub raw mirror into `data/` (gitignored). Of the 1034 dev queries, ~71 have >=2 join edges
+  (65 with 2, 6 with 3); Spider dev is join-shallow, so deep multi-hop strata require BIRD instead.
+- Default models: `anthropic/claude-sonnet-4.6` and `deepseek/deepseek-v4-flash`, via OpenRouter's
+  OpenAI-compatible endpoint.

--- a/experiments/mermaid-joinpath-eval/mje/anonymize.py
+++ b/experiments/mermaid-joinpath-eval/mje/anonymize.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mje.schema_graph import Column, FKEdge, SchemaGraph, edge_key
+
+
+@dataclass
+class Mapping:
+    table: dict[str, str] = field(default_factory=dict)  # orig table -> t{i}
+    column: dict[tuple[str, str], str] = field(
+        default_factory=dict
+    )  # (orig table, orig col) -> c{j}
+
+
+def anonymize(graph: SchemaGraph) -> tuple[SchemaGraph, Mapping]:
+    m = Mapping()
+    new_tables: dict[str, list[Column]] = {}
+    for ti, (tname, cols) in enumerate(graph.tables.items()):
+        new_t = f"t{ti}"
+        m.table[tname] = new_t
+        new_cols: list[Column] = []
+        for cj, col in enumerate(cols):
+            new_c = f"c{cj}"
+            m.column[(tname, col.name)] = new_c
+            new_cols.append(Column(table=new_t, name=new_c, type=col.type))
+        new_tables[new_t] = new_cols
+
+    new_edges: list[FKEdge] = []
+    for e in graph.fk_edges:
+        a = (m.table[e.a[0]], m.column[(e.a[0], e.a[1])])
+        b = (m.table[e.b[0]], m.column[(e.b[0], e.b[1])])
+        new_edges.append(FKEdge(a=a, b=b))
+
+    return SchemaGraph(db_id=graph.db_id, tables=new_tables, fk_edges=new_edges), m
+
+
+def _map_pair(pair: tuple[str, str], m: Mapping) -> tuple[str, str]:
+    tname, cname = pair
+    return m.table[tname], m.column[(tname, cname)]
+
+
+def map_edges(edges: set[frozenset], m: Mapping) -> set[frozenset]:
+    out: set[frozenset] = set()
+    for e in edges:
+        (p1, p2) = tuple(e)
+        out.add(edge_key(_map_pair(p1, m), _map_pair(p2, m)))
+    return out
+
+
+def map_tables(tables: set[str], m: Mapping) -> set[str]:
+    return {m.table[t] for t in tables}

--- a/experiments/mermaid-joinpath-eval/mje/anonymize.py
+++ b/experiments/mermaid-joinpath-eval/mje/anonymize.py
@@ -14,22 +14,24 @@ class Mapping:
 
 
 def anonymize(graph: SchemaGraph) -> tuple[SchemaGraph, Mapping]:
+    # Keys in Mapping are normalised to lowercase so they stay consistent with the
+    # lowercased pairs produced by edge_key() in extract_gold_edges().
     m = Mapping()
     new_tables: dict[str, list[Column]] = {}
     for ti, (tname, cols) in enumerate(graph.tables.items()):
         new_t = f"t{ti}"
-        m.table[tname] = new_t
+        m.table[tname.lower()] = new_t
         new_cols: list[Column] = []
         for cj, col in enumerate(cols):
             new_c = f"c{cj}"
-            m.column[(tname, col.name)] = new_c
+            m.column[(tname.lower(), col.name.lower())] = new_c
             new_cols.append(Column(table=new_t, name=new_c, type=col.type))
         new_tables[new_t] = new_cols
 
     new_edges: list[FKEdge] = []
     for e in graph.fk_edges:
-        a = (m.table[e.a[0]], m.column[(e.a[0], e.a[1])])
-        b = (m.table[e.b[0]], m.column[(e.b[0], e.b[1])])
+        a = (m.table[e.a[0].lower()], m.column[(e.a[0].lower(), e.a[1].lower())])
+        b = (m.table[e.b[0].lower()], m.column[(e.b[0].lower(), e.b[1].lower())])
         new_edges.append(FKEdge(a=a, b=b))
 
     return SchemaGraph(db_id=graph.db_id, tables=new_tables, fk_edges=new_edges), m
@@ -49,4 +51,4 @@ def map_edges(edges: set[frozenset], m: Mapping) -> set[frozenset]:
 
 
 def map_tables(tables: set[str], m: Mapping) -> set[str]:
-    return {m.table[t] for t in tables}
+    return {m.table[t.lower()] for t in tables}

--- a/experiments/mermaid-joinpath-eval/mje/data.py
+++ b/experiments/mermaid-joinpath-eval/mje/data.py
@@ -19,6 +19,10 @@ from mje.schema_graph import (
 SPIDER_TABLES_URL = "https://raw.githubusercontent.com/taoyds/spider/master/evaluation_examples/examples/tables.json"
 SPIDER_DEV_URL = "https://raw.githubusercontent.com/taoyds/spider/master/evaluation_examples/examples/dev.json"
 
+# BIRD mini-dev JSON sources.
+BIRD_TABLES_URL = "https://raw.githubusercontent.com/Harris-X/NLP2SQL/main/LLaMA-Factory/datasets/minidev/MINIDEV/dev_tables.json"
+BIRD_DEV_URL = "https://huggingface.co/datasets/birdsql/bird_mini_dev/resolve/main/data/mini_dev_sqlite-00000-of-00001.json"
+
 
 @dataclass
 class Item:
@@ -38,6 +42,17 @@ def download_spider(dest: Path) -> tuple[Path, Path]:
     for url, p in [(SPIDER_TABLES_URL, tables_p), (SPIDER_DEV_URL, dev_p)]:
         if not p.exists():
             r = requests.get(url, timeout=60)
+            r.raise_for_status()
+            p.write_bytes(r.content)
+    return tables_p, dev_p
+
+
+def download_bird(dest: Path) -> tuple[Path, Path]:
+    dest.mkdir(parents=True, exist_ok=True)
+    tables_p, dev_p = dest / "dev_tables.json", dest / "mini_dev_sqlite.json"
+    for url, p in [(BIRD_TABLES_URL, tables_p), (BIRD_DEV_URL, dev_p)]:
+        if not p.exists():
+            r = requests.get(url, timeout=120)
             r.raise_for_status()
             p.write_bytes(r.content)
     return tables_p, dev_p
@@ -72,7 +87,11 @@ def _ambiguous(raw_graph: SchemaGraph, used_tables: set[str]) -> bool:
 
 
 def build_items(
-    tables_path: Path, dev_path: Path, min_joins: int = 2, limit: int | None = None
+    tables_path: Path,
+    dev_path: Path,
+    min_joins: int = 2,
+    limit: int | None = None,
+    query_key: str = "query",
 ) -> list[Item]:
     tables = {
         e["db_id"]: parse_tables_json(e)
@@ -82,7 +101,7 @@ def build_items(
 
     items: list[Item] = []
     for i, ex in enumerate(dev):
-        db_id, query = ex["db_id"], ex["query"]
+        db_id, query = ex["db_id"], ex[query_key]
         graph = tables.get(db_id)
         if graph is None:
             continue
@@ -92,6 +111,10 @@ def build_items(
         except Exception:  # noqa: BLE001 — bad query must not abort whole build
             continue
         if len(gold) < min_joins:
+            continue
+        # Guard: skip items where gold edges reference non-existent tables (e.g. CTEs).
+        valid_tables = {t.lower() for t in graph.tables}
+        if any(tn.lower() not in valid_tables for pair in gold for (tn, _cn) in pair):
             continue
         ambiguous = _ambiguous(graph, used)
         anon_graph, m = anonymize(graph)

--- a/experiments/mermaid-joinpath-eval/mje/data.py
+++ b/experiments/mermaid-joinpath-eval/mje/data.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+from mje.anonymize import anonymize, map_edges, map_tables
+from mje.schema_graph import (
+    SchemaGraph,
+    extract_gold_edges,
+    gold_tables,
+    parse_tables_json,
+)
+
+# Spider dev/tables JSON (HuggingFace mirror).
+# If this 404s, download Spider manually and pass --tables/--dev paths to the runner.
+SPIDER_TABLES_URL = (
+    "https://huggingface.co/datasets/xlangai/spider/resolve/main/spider/tables.json"
+)
+SPIDER_DEV_URL = (
+    "https://huggingface.co/datasets/xlangai/spider/resolve/main/spider/dev.json"
+)
+
+
+@dataclass
+class Item:
+    item_id: str
+    db_id: str
+    query: str
+    graph: SchemaGraph  # anonymized
+    gold_edges: set[frozenset]  # anonymized
+    endpoint_tables: list[str]  # anonymized, sorted
+    n_joins: int
+    ambiguous: bool
+
+
+def download_spider(dest: Path) -> tuple[Path, Path]:
+    dest.mkdir(parents=True, exist_ok=True)
+    tables_p, dev_p = dest / "tables.json", dest / "dev.json"
+    for url, p in [(SPIDER_TABLES_URL, tables_p), (SPIDER_DEV_URL, dev_p)]:
+        if not p.exists():
+            r = requests.get(url, timeout=60)
+            r.raise_for_status()
+            p.write_bytes(r.content)
+    return tables_p, dev_p
+
+
+def _ambiguous(raw_graph: SchemaGraph, used_tables: set[str]) -> bool:
+    # connected component spanning used_tables; cycle (edges >= nodes) => multiple paths
+    adj: dict[str, set[str]] = {t: set() for t in raw_graph.tables}
+    edge_set: set[frozenset] = set()
+    for e in raw_graph.fk_edges:
+        ta, tb = e.a[0], e.b[0]
+        if ta != tb:
+            adj[ta].add(tb)
+            adj[tb].add(ta)
+            edge_set.add(frozenset({ta, tb}))
+    seen: set[str] = set()
+    stack = list(used_tables)
+    while stack:
+        n = stack.pop()
+        if n in seen:
+            continue
+        seen.add(n)
+        stack.extend(adj[n] - seen)
+    comp_edges = [e for e in edge_set if set(e) <= seen]
+    return len(comp_edges) >= len(seen) and len(seen) > 0
+
+
+def build_items(
+    tables_path: Path, dev_path: Path, min_joins: int = 2, limit: int | None = None
+) -> list[Item]:
+    tables = {
+        e["db_id"]: parse_tables_json(e)
+        for e in json.loads(Path(tables_path).read_text())
+    }
+    dev = json.loads(Path(dev_path).read_text())
+
+    items: list[Item] = []
+    for i, ex in enumerate(dev):
+        db_id, query = ex["db_id"], ex["query"]
+        graph = tables.get(db_id)
+        if graph is None:
+            continue
+        try:
+            gold = extract_gold_edges(query, graph)
+            used = gold_tables(query, graph)
+        except Exception:  # noqa: BLE001 — bad query must not abort whole build
+            continue
+        if len(gold) < min_joins:
+            continue
+        ambiguous = _ambiguous(graph, used)
+        anon_graph, m = anonymize(graph)
+        items.append(
+            Item(
+                item_id=f"{db_id}-{i}",
+                db_id=db_id,
+                query=query,
+                graph=anon_graph,
+                gold_edges=map_edges(gold, m),
+                endpoint_tables=sorted(map_tables(used, m)),
+                n_joins=len(gold),
+                ambiguous=ambiguous,
+            )
+        )
+        if limit and len(items) >= limit:
+            break
+    return items

--- a/experiments/mermaid-joinpath-eval/mje/data.py
+++ b/experiments/mermaid-joinpath-eval/mje/data.py
@@ -14,14 +14,10 @@ from mje.schema_graph import (
     parse_tables_json,
 )
 
-# Spider dev/tables JSON (HuggingFace mirror).
+# Spider dev/tables JSON — taoyds/spider raw GitHub source (evaluation_examples mirror).
 # If this 404s, download Spider manually and pass --tables/--dev paths to the runner.
-SPIDER_TABLES_URL = (
-    "https://huggingface.co/datasets/xlangai/spider/resolve/main/spider/tables.json"
-)
-SPIDER_DEV_URL = (
-    "https://huggingface.co/datasets/xlangai/spider/resolve/main/spider/dev.json"
-)
+SPIDER_TABLES_URL = "https://raw.githubusercontent.com/taoyds/spider/master/evaluation_examples/examples/tables.json"
+SPIDER_DEV_URL = "https://raw.githubusercontent.com/taoyds/spider/master/evaluation_examples/examples/dev.json"
 
 
 @dataclass
@@ -48,6 +44,12 @@ def download_spider(dest: Path) -> tuple[Path, Path]:
 
 
 def _ambiguous(raw_graph: SchemaGraph, used_tables: set[str]) -> bool:
+    # Conservative proxy for join-path ambiguity (intentional for this experiment).
+    # Limitations:
+    #   (a) Treats the FK graph as a simple graph — two distinct FK column-pairs between
+    #       the same table pair collapse to one edge, so ambiguity is under-counted.
+    #   (b) If the used tables span multiple disconnected FK components the cycle test
+    #       runs over the union of those components and may produce a false negative.
     # connected component spanning used_tables; cycle (edges >= nodes) => multiple paths
     adj: dict[str, set[str]] = {t: set() for t in raw_graph.tables}
     edge_set: set[frozenset] = set()
@@ -105,6 +107,6 @@ def build_items(
                 ambiguous=ambiguous,
             )
         )
-        if limit and len(items) >= limit:
+        if limit is not None and len(items) >= limit:
             break
     return items

--- a/experiments/mermaid-joinpath-eval/mje/grade.py
+++ b/experiments/mermaid-joinpath-eval/mje/grade.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import re
+
+import sqlglot
+from sqlglot import exp
+
+from mje.schema_graph import SchemaGraph, edge_key
+
+_COND = re.compile(
+    r"([A-Za-z_]\w*)\.([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.([A-Za-z_]\w*)"
+)
+
+
+def _fk_keys(graph: SchemaGraph) -> set[frozenset]:
+    return {edge_key(e.a, e.b) for e in graph.fk_edges}
+
+
+def _extract_json_block(text: str) -> list[str] | None:
+    cleaned = re.sub(r"```[a-zA-Z]*", "", text).replace("```", "")
+    start = cleaned.find("[")
+    end = cleaned.rfind("]")
+    if start == -1 or end == -1 or end < start:
+        return None
+    try:
+        val = json.loads(cleaned[start : end + 1])
+        return [str(x) for x in val] if isinstance(val, list) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def parse_pred_edges(text: str, graph: SchemaGraph) -> set[frozenset]:
+    edges: set[frozenset] = set()
+
+    items = _extract_json_block(text)
+    if items is not None:
+        for cond in items:
+            mt = _COND.search(cond)
+            if mt:
+                t1, c1, t2, c2 = mt.groups()
+                edges.add(edge_key((t1, c1), (t2, c2)))
+        if edges:
+            return edges
+
+    try:
+        ast = sqlglot.parse_one(text, read="sqlite")
+        for eq in ast.find_all(exp.EQ):
+            lhs, rhs = eq.left, eq.right
+            if (
+                isinstance(lhs, exp.Column)
+                and isinstance(rhs, exp.Column)
+                and lhs.table
+                and rhs.table
+            ):
+                edges.add(edge_key((lhs.table, lhs.name), (rhs.table, rhs.name)))
+    except Exception:
+        pass
+    return edges
+
+
+def score(pred: set[frozenset], gold: set[frozenset], graph: SchemaGraph) -> dict:
+    fk = _fk_keys(graph)
+    tp = len(pred & gold)
+    precision = tp / len(pred) if pred else 0.0
+    recall = tp / len(gold) if gold else 0.0
+    f1 = (
+        (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    )
+    hallucinated = len([e for e in pred if e not in fk])
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "exact": pred == gold,
+        "hallucinated": hallucinated,
+        "n_pred": len(pred),
+        "n_gold": len(gold),
+    }

--- a/experiments/mermaid-joinpath-eval/mje/model_client.py
+++ b/experiments/mermaid-joinpath-eval/mje/model_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import time
+
+# USD per million tokens. Source: OpenRouter pricing.
+PRICING = {
+    "anthropic/claude-sonnet-4.6": {"in": 3.0, "out": 15.0},
+    "deepseek/deepseek-v4-flash": {"in": 0.0983, "out": 0.1966},
+}
+
+
+def cost(model: str, in_tok: int, out_tok: int) -> float:
+    """Return cost in USD. PRICING values are USD per 1 M tokens."""
+    p = PRICING[model]
+    return (in_tok * p["in"] + out_tok * p["out"]) / 1_000_000
+
+
+class ModelClient:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str = "https://openrouter.ai/api/v1",
+        client=None,
+    ):
+        if client is not None:
+            self._client = client
+        else:
+            from openai import OpenAI
+
+            key = api_key or os.environ["OPENROUTER_API_KEY"]
+            self._client = OpenAI(api_key=key, base_url=base_url)
+
+    def call(
+        self, model: str, messages: list[dict], max_tokens: int = 256, retries: int = 3
+    ) -> tuple[str, int, int]:
+        last = None
+        for attempt in range(retries):
+            try:
+                resp = self._client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    temperature=0,
+                    max_tokens=max_tokens,
+                )
+                text = resp.choices[0].message.content or ""
+                u = resp.usage
+                return text, int(u.prompt_tokens), int(u.completion_tokens)
+            except Exception as e:  # noqa: BLE001
+                last = e
+                time.sleep(2**attempt)
+        raise RuntimeError(f"model call failed after {retries} retries: {last}")

--- a/experiments/mermaid-joinpath-eval/mje/prompt.py
+++ b/experiments/mermaid-joinpath-eval/mje/prompt.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+SYSTEM = (
+    "You connect database tables. Given a schema and a set of tables, output ONLY the "
+    "JOIN conditions needed to connect those tables into one query. Use only columns "
+    "that appear in the schema. Respond with a JSON array of strings like "
+    '["ta.cx = tb.cy", ...] and nothing else.'
+)
+
+USER_TEMPLATE = (
+    "Schema:\n{rendering}\n\n"
+    "Connect these tables into a single joined query: {tables}.\n"
+    "Return the minimal set of join conditions as a JSON array of "
+    '"ta.cx = tb.cy" strings.'
+)
+
+
+def build_messages(rendering: str, endpoint_tables: list[str]) -> list[dict]:
+    tables = ", ".join(endpoint_tables)
+    return [
+        {"role": "system", "content": SYSTEM},
+        {
+            "role": "user",
+            "content": USER_TEMPLATE.format(rendering=rendering, tables=tables),
+        },
+    ]

--- a/experiments/mermaid-joinpath-eval/mje/renderers.py
+++ b/experiments/mermaid-joinpath-eval/mje/renderers.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from mje.schema_graph import FKEdge, SchemaGraph
+
+
+def _sorted_tables(graph: SchemaGraph) -> list[str]:
+    return sorted(graph.tables)
+
+
+def _sorted_edges(graph: SchemaGraph) -> list[FKEdge]:
+    def key(e: FKEdge):
+        return tuple(sorted([f"{e.a[0]}.{e.a[1]}", f"{e.b[0]}.{e.b[1]}"]))
+
+    return sorted(graph.fk_edges, key=key)
+
+
+def render_xml(graph: SchemaGraph) -> str:
+    lines = ["<schema>"]
+    for t in _sorted_tables(graph):
+        cols = "".join(
+            f'<column name="{c.name}" type="{c.type}"/>' for c in graph.tables[t]
+        )
+        lines.append(f'  <table name="{t}">{cols}</table>')
+    lines.append("  <relationships>")
+    for e in _sorted_edges(graph):
+        from_col = f"{e.a[0]}.{e.a[1]}"
+        to_col = f"{e.b[0]}.{e.b[1]}"
+        lines.append(f'    <rel from="{from_col}" to="{to_col}" type="many_to_one"/>')
+    lines.append("  </relationships>")
+    lines.append("</schema>")
+    return "\n".join(lines)
+
+
+def render_mermaid(graph: SchemaGraph) -> str:
+    lines = ["erDiagram"]
+    for t in _sorted_tables(graph):
+        body = "  ".join(f"{c.type} {c.name}" for c in graph.tables[t])
+        lines.append(f"  {t} {{ {body} }}")
+    for e in _sorted_edges(graph):
+        lines.append(f'  {e.a[0]} ||--o{{ {e.b[0]} : "{e.a[1]} = {e.b[1]}"')
+    return "\n".join(lines)
+
+
+def render_nl_adjacency(graph: SchemaGraph) -> str:
+    lines = []
+    for t in _sorted_tables(graph):
+        cols = ", ".join(f"{c.name} ({c.type})" for c in graph.tables[t])
+        lines.append(f"{t} has columns {cols}.")
+    for e in _sorted_edges(graph):
+        join_expr = f"{e.a[0]}.{e.a[1]} = {e.b[0]}.{e.b[1]}"
+        lines.append(f"{e.a[0]} joins to {e.b[0]} via {join_expr} (many_to_one).")
+    return "\n".join(lines)
+
+
+RENDERERS = {
+    "xml": render_xml,
+    "mermaid": render_mermaid,
+    "nl_adjacency": render_nl_adjacency,
+}

--- a/experiments/mermaid-joinpath-eval/mje/renderers.py
+++ b/experiments/mermaid-joinpath-eval/mje/renderers.py
@@ -41,6 +41,24 @@ def render_mermaid(graph: SchemaGraph) -> str:
     return "\n".join(lines)
 
 
+def render_mermaid_qualified(graph: SchemaGraph) -> str:
+    """Mermaid erDiagram with fully table-qualified join columns in edge labels.
+
+    Identical to render_mermaid except the relationship label reads
+    "t1.c0 = t3.c2" instead of "c0 = c2", matching the explicitness of the
+    XML and NL-adjacency renderings. Used to test whether mermaid's deficit is
+    the notation itself or under-qualified edge labels.
+    """
+    lines = ["erDiagram"]
+    for t in _sorted_tables(graph):
+        body = "  ".join(f"{c.type} {c.name}" for c in graph.tables[t])
+        lines.append(f"  {t} {{ {body} }}")
+    for e in _sorted_edges(graph):
+        label = f"{e.a[0]}.{e.a[1]} = {e.b[0]}.{e.b[1]}"
+        lines.append(f'  {e.a[0]} ||--o{{ {e.b[0]} : "{label}"')
+    return "\n".join(lines)
+
+
 def render_nl_adjacency(graph: SchemaGraph) -> str:
     lines = []
     for t in _sorted_tables(graph):
@@ -55,5 +73,6 @@ def render_nl_adjacency(graph: SchemaGraph) -> str:
 RENDERERS = {
     "xml": render_xml,
     "mermaid": render_mermaid,
+    "mermaid_qualified": render_mermaid_qualified,
     "nl_adjacency": render_nl_adjacency,
 }

--- a/experiments/mermaid-joinpath-eval/mje/runner.py
+++ b/experiments/mermaid-joinpath-eval/mje/runner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from mje.data import Item, build_items, download_spider
 from mje.grade import parse_pred_edges, score
-from mje.model_client import ModelClient, cost
+from mje.model_client import PRICING, ModelClient, cost
 from mje.prompt import build_messages
 from mje.renderers import RENDERERS
 
@@ -42,7 +42,8 @@ def run_eval(
                         text, in_tok, out_tok = client.call(
                             model, messages, max_tokens=max_tokens
                         )
-                        spent += cost(model, in_tok, out_tok)
+                        call_cost = cost(model, in_tok, out_tok)
+                        spent += call_cost
                         pred = parse_pred_edges(text, it.graph)
                         sc = score(pred, it.gold_edges, it.graph)
                         row = {
@@ -55,7 +56,7 @@ def run_eval(
                             "sample": s,
                             "in_tok": in_tok,
                             "out_tok": out_tok,
-                            "cost_usd": cost(model, in_tok, out_tok),
+                            "cost_usd": call_cost,
                             **sc,
                             "gold_edges": [
                                 sorted(tuple(p) for p in e) for e in it.gold_edges
@@ -87,6 +88,10 @@ def main() -> None:
         default=["anthropic/claude-sonnet-4.6", "deepseek/deepseek-v4-flash"],
     )
     args = ap.parse_args()
+
+    unknown = [m for m in args.models if m not in PRICING]
+    if unknown:
+        raise SystemExit(f"Unknown model(s): {unknown}. Supported: {sorted(PRICING)}")
 
     if args.tables and args.dev:
         tables_p, dev_p = Path(args.tables), Path(args.dev)

--- a/experiments/mermaid-joinpath-eval/mje/runner.py
+++ b/experiments/mermaid-joinpath-eval/mje/runner.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from mje.data import Item, build_items, download_spider
+from mje.data import Item, build_items, download_bird, download_spider
 from mje.grade import parse_pred_edges, score
 from mje.model_client import PRICING, ModelClient, cost
 from mje.prompt import build_messages
@@ -95,18 +95,29 @@ def main() -> None:
         nargs="+",
         default=["anthropic/claude-sonnet-4.6", "deepseek/deepseek-v4-flash"],
     )
+    ap.add_argument("--dataset", choices=["spider", "bird"], default="spider")
+    ap.add_argument("--query-key", default=None)
     args = ap.parse_args()
 
     unknown = [m for m in args.models if m not in PRICING]
     if unknown:
         raise SystemExit(f"Unknown model(s): {unknown}. Supported: {sorted(PRICING)}")
 
+    if args.query_key is not None:
+        query_key = args.query_key
+    elif args.dataset == "bird":
+        query_key = "SQL"
+    else:
+        query_key = "query"
+
     if args.tables and args.dev:
         tables_p, dev_p = Path(args.tables), Path(args.dev)
+    elif args.dataset == "bird":
+        tables_p, dev_p = download_bird(Path(args.data_dir) / "bird")
     else:
         tables_p, dev_p = download_spider(Path(args.data_dir))
 
-    items = build_items(tables_p, dev_p, min_joins=args.min_joins)
+    items = build_items(tables_p, dev_p, min_joins=args.min_joins, query_key=query_key)
     items.sort(key=lambda it: it.n_joins, reverse=True)
     items = items[: args.n]
 

--- a/experiments/mermaid-joinpath-eval/mje/runner.py
+++ b/experiments/mermaid-joinpath-eval/mje/runner.py
@@ -17,7 +17,7 @@ def run_eval(
     client,
     out_path: Path,
     max_spend: float = 2.0,
-    max_tokens: int = 256,
+    max_tokens: int = 4096,
     samples: int = 1,
 ) -> list[dict]:
     out_path = Path(out_path)
@@ -56,7 +56,9 @@ def run_eval(
                             "sample": s,
                             "in_tok": in_tok,
                             "out_tok": out_tok,
+                            "truncated": out_tok >= max_tokens,
                             "cost_usd": call_cost,
+                            "raw": text[:1000],
                             **sc,
                             "gold_edges": [
                                 sorted(tuple(p) for p in e) for e in it.gold_edges
@@ -81,6 +83,12 @@ def main() -> None:
         "--n", type=int, default=45, help="max items (hardest strata first)"
     )
     ap.add_argument("--samples", type=int, default=1)
+    ap.add_argument(
+        "--max-tokens",
+        type=int,
+        default=4096,
+        help="output token cap; must be high enough for reasoning models",
+    )
     ap.add_argument("--max-spend", type=float, default=2.0)
     ap.add_argument(
         "--models",
@@ -118,6 +126,7 @@ def main() -> None:
         client=client,
         out_path=Path(args.out),
         max_spend=args.max_spend,
+        max_tokens=args.max_tokens,
         samples=args.samples,
     )
 

--- a/experiments/mermaid-joinpath-eval/mje/runner.py
+++ b/experiments/mermaid-joinpath-eval/mje/runner.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from mje.data import Item, build_items, download_spider
+from mje.grade import parse_pred_edges, score
+from mje.model_client import ModelClient, cost
+from mje.prompt import build_messages
+from mje.renderers import RENDERERS
+
+
+def run_eval(
+    items: list[Item],
+    models: list[str],
+    client,
+    out_path: Path,
+    max_spend: float = 2.0,
+    max_tokens: int = 256,
+    samples: int = 1,
+) -> list[dict]:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[dict] = []
+    spent = 0.0
+    EST_PER_CALL = 0.02  # conservative pre-call guess (USD) for the budget gate
+
+    with out_path.open("w") as fh:
+        for it in items:
+            for rname, rfn in RENDERERS.items():
+                rendering = rfn(it.graph)
+                messages = build_messages(rendering, it.endpoint_tables)
+                for model in models:
+                    for s in range(samples):
+                        if spent + EST_PER_CALL > max_spend:
+                            print(
+                                "[budget] stopping: spent"
+                                f" ${spent:.3f}, cap ${max_spend:.2f}"
+                            )
+                            return rows
+                        text, in_tok, out_tok = client.call(
+                            model, messages, max_tokens=max_tokens
+                        )
+                        spent += cost(model, in_tok, out_tok)
+                        pred = parse_pred_edges(text, it.graph)
+                        sc = score(pred, it.gold_edges, it.graph)
+                        row = {
+                            "item_id": it.item_id,
+                            "db_id": it.db_id,
+                            "n_joins": it.n_joins,
+                            "ambiguous": it.ambiguous,
+                            "model": model,
+                            "rendering": rname,
+                            "sample": s,
+                            "in_tok": in_tok,
+                            "out_tok": out_tok,
+                            "cost_usd": cost(model, in_tok, out_tok),
+                            **sc,
+                            "gold_edges": [
+                                sorted(tuple(p) for p in e) for e in it.gold_edges
+                            ],
+                            "pred_edges": [sorted(tuple(p) for p in e) for e in pred],
+                        }
+                        fh.write(json.dumps(row) + "\n")
+                        fh.flush()
+                        rows.append(row)
+    print(f"[done] {len(rows)} calls, spent ${spent:.3f}")
+    return rows
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-dir", default="data")
+    ap.add_argument("--tables", default=None, help="override tables.json path")
+    ap.add_argument("--dev", default=None, help="override dev.json path")
+    ap.add_argument("--out", default="results/results.jsonl")
+    ap.add_argument("--min-joins", type=int, default=2)
+    ap.add_argument(
+        "--n", type=int, default=45, help="max items (hardest strata first)"
+    )
+    ap.add_argument("--samples", type=int, default=1)
+    ap.add_argument("--max-spend", type=float, default=2.0)
+    ap.add_argument(
+        "--models",
+        nargs="+",
+        default=["anthropic/claude-sonnet-4.6", "deepseek/deepseek-v4-flash"],
+    )
+    args = ap.parse_args()
+
+    if args.tables and args.dev:
+        tables_p, dev_p = Path(args.tables), Path(args.dev)
+    else:
+        tables_p, dev_p = download_spider(Path(args.data_dir))
+
+    items = build_items(tables_p, dev_p, min_joins=args.min_joins)
+    items.sort(key=lambda it: it.n_joins, reverse=True)
+    items = items[: args.n]
+
+    est = len(items) * len(RENDERERS) * len(args.models) * args.samples * 0.02
+    n_items = len(items)
+    n_renderings = len(RENDERERS)
+    n_models = len(args.models)
+    print(
+        f"[plan] {n_items} items x {n_renderings} renderings x {n_models} models "
+        f"x {args.samples} sample(s); rough est ${est:.2f}; cap ${args.max_spend:.2f}"
+    )
+
+    client = ModelClient()
+    run_eval(
+        items,
+        models=args.models,
+        client=client,
+        out_path=Path(args.out),
+        max_spend=args.max_spend,
+        samples=args.samples,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/mermaid-joinpath-eval/mje/runner.py
+++ b/experiments/mermaid-joinpath-eval/mje/runner.py
@@ -19,16 +19,18 @@ def run_eval(
     max_spend: float = 2.0,
     max_tokens: int = 4096,
     samples: int = 1,
+    renderings: dict | None = None,
 ) -> list[dict]:
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     rows: list[dict] = []
     spent = 0.0
     EST_PER_CALL = 0.02  # conservative pre-call guess (USD) for the budget gate
+    renderings = renderings if renderings is not None else RENDERERS
 
     with out_path.open("w") as fh:
         for it in items:
-            for rname, rfn in RENDERERS.items():
+            for rname, rfn in renderings.items():
                 rendering = rfn(it.graph)
                 messages = build_messages(rendering, it.endpoint_tables)
                 for model in models:
@@ -97,6 +99,13 @@ def main() -> None:
     )
     ap.add_argument("--dataset", choices=["spider", "bird"], default="spider")
     ap.add_argument("--query-key", default=None)
+    ap.add_argument(
+        "--renderings",
+        nargs="+",
+        default=None,
+        choices=list(RENDERERS),
+        help="subset of renderings to run (default: all)",
+    )
     args = ap.parse_args()
 
     unknown = [m for m in args.models if m not in PRICING]
@@ -121,9 +130,13 @@ def main() -> None:
     items.sort(key=lambda it: it.n_joins, reverse=True)
     items = items[: args.n]
 
-    est = len(items) * len(RENDERERS) * len(args.models) * args.samples * 0.02
+    renderings = (
+        {k: RENDERERS[k] for k in args.renderings} if args.renderings else RENDERERS
+    )
+
+    est = len(items) * len(renderings) * len(args.models) * args.samples * 0.02
     n_items = len(items)
-    n_renderings = len(RENDERERS)
+    n_renderings = len(renderings)
     n_models = len(args.models)
     print(
         f"[plan] {n_items} items x {n_renderings} renderings x {n_models} models "
@@ -139,6 +152,7 @@ def main() -> None:
         max_spend=args.max_spend,
         max_tokens=args.max_tokens,
         samples=args.samples,
+        renderings=renderings,
     )
 
 

--- a/experiments/mermaid-joinpath-eval/mje/schema_graph.py
+++ b/experiments/mermaid-joinpath-eval/mje/schema_graph.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.optimizer.qualify import qualify
+
+
+@dataclass(frozen=True)
+class Column:
+    table: str
+    name: str
+    type: str
+
+
+@dataclass
+class FKEdge:
+    a: tuple[str, str]  # (table, column)
+    b: tuple[str, str]
+
+
+@dataclass
+class SchemaGraph:
+    db_id: str
+    tables: dict[str, list[Column]] = field(default_factory=dict)
+    fk_edges: list[FKEdge] = field(default_factory=list)
+
+
+def edge_key(a: tuple[str, str], b: tuple[str, str]) -> frozenset:
+    """Undirected key for a join edge, lowercased for stable comparison."""
+    return frozenset({(a[0].lower(), a[1].lower()), (b[0].lower(), b[1].lower())})
+
+
+def parse_tables_json(entry: dict) -> SchemaGraph:
+    table_names = entry["table_names_original"]
+    col_defs = entry[
+        "column_names_original"
+    ]  # [[t_idx, name], ...] ; index 0 is [-1,"*"]
+    col_types = entry["column_types"]
+
+    tables: dict[str, list[Column]] = {t: [] for t in table_names}
+    col_ref: dict[int, tuple[str, str]] = {}
+    for idx, (t_idx, cname) in enumerate(col_defs):
+        if t_idx < 0:
+            continue
+        tname = table_names[t_idx]
+        ctype = col_types[idx] if idx < len(col_types) else "text"
+        tables[tname].append(Column(table=tname, name=cname, type=ctype))
+        col_ref[idx] = (tname, cname)
+
+    fk_edges: list[FKEdge] = []
+    for c1, c2 in entry.get("foreign_keys", []):
+        if c1 in col_ref and c2 in col_ref:
+            fk_edges.append(FKEdge(a=col_ref[c1], b=col_ref[c2]))
+
+    return SchemaGraph(db_id=entry["db_id"], tables=tables, fk_edges=fk_edges)
+
+
+def _schema_dict(graph: SchemaGraph) -> dict[str, Any]:
+    """Schema mapping sqlglot's qualifier understands: {table: {col: type}}."""
+    return {
+        t: {c.name: (c.type or "text").upper() for c in cols}
+        for t, cols in graph.tables.items()
+    }
+
+
+def _qualified_ast(query: str, graph: SchemaGraph) -> Any:
+    ast = sqlglot.parse_one(query, read="sqlite")
+    return qualify(
+        ast,
+        schema=_schema_dict(graph),
+        qualify_columns=True,
+        validate_qualify_columns=False,
+    )
+
+
+def _alias_map(ast: exp.Expression) -> dict[str, str]:
+    """Build a mapping from alias_or_name (lowercased) -> actual table name."""
+    result: dict[str, str] = {}
+    for source in ast.find_all(exp.Table):
+        alias = (source.alias or source.name or "").lower()
+        if alias:
+            result[alias] = source.name
+    return result
+
+
+def extract_gold_edges(query: str, graph: SchemaGraph) -> set[frozenset]:
+    """Return the set of undirected join edges (column == column across tables)."""
+    ast = _qualified_ast(query, graph)
+    alias_to_table = _alias_map(ast)
+    edges: set[frozenset] = set()
+    for eq in ast.find_all(exp.EQ):
+        left, right = eq.left, eq.right
+        if isinstance(left, exp.Column) and isinstance(right, exp.Column):
+            lt_alias = left.table.lower() if left.table else None
+            rt_alias = right.table.lower() if right.table else None
+            lt = alias_to_table.get(lt_alias) if lt_alias else None
+            rt = alias_to_table.get(rt_alias) if rt_alias else None
+            if lt and rt and lt.lower() != rt.lower():
+                edges.add(edge_key((lt, left.name), (rt, right.name)))
+    return edges
+
+
+def gold_tables(query: str, graph: SchemaGraph) -> set[str]:
+    ast = _qualified_ast(query, graph)
+    valid = {k.lower(): k for k in graph.tables}
+    return {
+        valid[t.name.lower()]
+        for t in ast.find_all(exp.Table)
+        if t.name.lower() in valid
+    }

--- a/experiments/mermaid-joinpath-eval/mje/stats.py
+++ b/experiments/mermaid-joinpath-eval/mje/stats.py
@@ -13,10 +13,23 @@ def _stratum(n_joins: int) -> str:
     return "2" if n_joins == 2 else "3" if n_joins == 3 else "4+"
 
 
-def aggregate(rows: list[dict]) -> list[dict]:
+def _is_parse_failure(r: dict) -> bool:
+    """No parseable join edge came back (every item has >=2 gold joins, so an
+    empty prediction is a parse/refusal failure, not a legitimate answer).
+
+    Counted separately so parse failures don't masquerade as reasoning failures
+    and so an asymmetric parse-failure rate across renderings can be detected.
+    """
+    return len(r.get("pred_edges", [])) == 0
+
+
+def aggregate(rows: list[dict], exclude_truncated: bool = False) -> list[dict]:
+    if exclude_truncated:
+        rows = [r for r in rows if not r.get("truncated")]
     groups: dict[tuple, list[dict]] = defaultdict(list)
     for r in rows:
-        for st in ("all", _stratum(r["n_joins"])):
+        ambig = "ambig" if r.get("ambiguous") else "unambig"
+        for st in ("all", _stratum(r["n_joins"]), ambig):
             groups[(r["model"], r["rendering"], st)].append(r)
     out = []
     for (model, rendering, st), rs in sorted(groups.items()):
@@ -29,41 +42,66 @@ def aggregate(rows: list[dict]) -> list[dict]:
                 "n": n,
                 "mean_f1": sum(r["f1"] for r in rs) / n,
                 "exact_rate": sum(1 for r in rs if r["exact"]) / n,
+                "parse_fail_rate": sum(1 for r in rs if _is_parse_failure(r)) / n,
+                "truncated_rate": sum(1 for r in rs if r.get("truncated")) / n,
             }
         )
     return out
 
 
-def mcnemar_pairs(rows: list[dict], model: str) -> list[dict]:
-    by: dict[tuple, bool] = {}
+def mcnemar_pairs(
+    rows: list[dict],
+    model: str,
+    exclude_truncated: bool = False,
+    ambiguity: str = "all",
+) -> list[dict]:
+    """Paired McNemar (exact-match) across rendering pairs for one model.
+
+    ``ambiguity`` selects the item subset: ``"all"`` (default), ``"unambig"``
+    (drop cycle-flagged items, where exact-match is unreliable), or ``"ambig"``.
+    ``exclude_truncated`` drops a pair if either side was output-token truncated.
+
+    Discordant counts are reported with keys tied to the actual ``a``/``b``
+    rendering names (``a_right_b_wrong`` / ``b_right_a_wrong``) so the direction
+    can never be mis-transcribed downstream.
+    """
+    by: dict[tuple, dict] = {}
     renderings: set[str] = set()
     items: set[str] = set()
     for r in rows:
         if r["model"] != model:
             continue
-        by[(r["item_id"], r["rendering"])] = bool(r["exact"])
+        if ambiguity == "unambig" and r.get("ambiguous"):
+            continue
+        if ambiguity == "ambig" and not r.get("ambiguous"):
+            continue
+        by[(r["item_id"], r["rendering"])] = r
         renderings.add(r["rendering"])
         items.add(r["item_id"])
 
     results = []
     for a, b in combinations(sorted(renderings, reverse=True), 2):
-        b01 = b10 = 0
+        a_wins = b_wins = 0
         for it in items:
-            if (it, a) in by and (it, b) in by:
-                ra, rb = by[(it, a)], by[(it, b)]
-                if not ra and rb:
-                    b01 += 1
-                elif ra and not rb:
-                    b10 += 1
-        n = b01 + b10
-        p = binomtest(b01, n, 0.5).pvalue if n > 0 else 1.0
+            ra, rb = by.get((it, a)), by.get((it, b))
+            if ra is None or rb is None:
+                continue
+            if exclude_truncated and (ra.get("truncated") or rb.get("truncated")):
+                continue
+            ea, eb = bool(ra["exact"]), bool(rb["exact"])
+            if ea and not eb:
+                a_wins += 1
+            elif eb and not ea:
+                b_wins += 1
+        n = a_wins + b_wins
+        p = binomtest(b_wins, n, 0.5).pvalue if n > 0 else 1.0
         results.append(
             {
                 "model": model,
                 "a": a,
                 "b": b,
-                "b_a_wrong_b_right": b01,
-                "b_a_right_b_wrong": b10,
+                "a_right_b_wrong": a_wins,
+                "b_right_a_wrong": b_wins,
                 "p_value": p,
             }
         )
@@ -79,24 +117,42 @@ def load_rows(path: Path) -> list[dict]:
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--results", default="results/results.jsonl")
+    ap.add_argument(
+        "--exclude-truncated",
+        action="store_true",
+        help="drop output-token-truncated rows (reproduces the 'clean' numbers)",
+    )
     args = ap.parse_args()
     rows = load_rows(Path(args.results))
 
-    print("\n=== mean F1 / exact-rate by model × rendering × stratum ===")
-    for r in aggregate(rows):
+    label = " (clean: truncated excluded)" if args.exclude_truncated else ""
+    print(f"\n=== mean F1 / exact / parse-fail / trunc by model × rendering{label} ===")
+    print("stratum legend: all | 2,3,4+ (join depth) | ambig,unambig (cycle proxy)")
+    for r in aggregate(rows, exclude_truncated=args.exclude_truncated):
         print(
-            f"{r['model']:<32} {r['rendering']:<13} {r['stratum']:<4} "
-            f"n={r['n']:<4} F1={r['mean_f1']:.3f} exact={r['exact_rate']:.3f}"
+            f"{r['model']:<32} {r['rendering']:<18} {r['stratum']:<8} "
+            f"n={r['n']:<4} F1={r['mean_f1']:.3f} exact={r['exact_rate']:.3f} "
+            f"parse_fail={r['parse_fail_rate']:.3f} trunc={r['truncated_rate']:.3f}"
         )
 
-    print("\n=== paired McNemar (exact-match) ===")
-    for model in sorted({r["model"] for r in rows}):
-        for res in mcnemar_pairs(rows, model):
-            print(
-                f"{model:<32} {res['a']} vs {res['b']}: "
-                f"disc {res['b_a_wrong_b_right']}/{res['b_a_right_b_wrong']} "
-                f"p={res['p_value']:.4f}"
-            )
+    for ambiguity in ("all", "unambig", "ambig"):
+        print(
+            f"\n=== paired McNemar (exact-match), items={ambiguity}"
+            f"{', truncated excluded' if args.exclude_truncated else ''} ==="
+        )
+        for model in sorted({r["model"] for r in rows}):
+            for res in mcnemar_pairs(
+                rows,
+                model,
+                exclude_truncated=args.exclude_truncated,
+                ambiguity=ambiguity,
+            ):
+                print(
+                    f"{model:<32} {res['a']} vs {res['b']}: "
+                    f"{res['a']}-right/{res['b']}-wrong={res['a_right_b_wrong']} "
+                    f"{res['b']}-right/{res['a']}-wrong={res['b_right_a_wrong']} "
+                    f"p={res['p_value']:.4f}"
+                )
 
 
 if __name__ == "__main__":

--- a/experiments/mermaid-joinpath-eval/mje/stats.py
+++ b/experiments/mermaid-joinpath-eval/mje/stats.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from itertools import combinations
+from pathlib import Path
+
+from scipy.stats import binomtest
+
+
+def _stratum(n_joins: int) -> str:
+    return "2" if n_joins == 2 else "3" if n_joins == 3 else "4+"
+
+
+def aggregate(rows: list[dict]) -> list[dict]:
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for r in rows:
+        for st in ("all", _stratum(r["n_joins"])):
+            groups[(r["model"], r["rendering"], st)].append(r)
+    out = []
+    for (model, rendering, st), rs in sorted(groups.items()):
+        n = len(rs)
+        out.append(
+            {
+                "model": model,
+                "rendering": rendering,
+                "stratum": st,
+                "n": n,
+                "mean_f1": sum(r["f1"] for r in rs) / n,
+                "exact_rate": sum(1 for r in rs if r["exact"]) / n,
+            }
+        )
+    return out
+
+
+def mcnemar_pairs(rows: list[dict], model: str) -> list[dict]:
+    by: dict[tuple, bool] = {}
+    renderings: set[str] = set()
+    items: set[str] = set()
+    for r in rows:
+        if r["model"] != model:
+            continue
+        by[(r["item_id"], r["rendering"])] = bool(r["exact"])
+        renderings.add(r["rendering"])
+        items.add(r["item_id"])
+
+    results = []
+    for a, b in combinations(sorted(renderings, reverse=True), 2):
+        b01 = b10 = 0
+        for it in items:
+            if (it, a) in by and (it, b) in by:
+                ra, rb = by[(it, a)], by[(it, b)]
+                if not ra and rb:
+                    b01 += 1
+                elif ra and not rb:
+                    b10 += 1
+        n = b01 + b10
+        p = binomtest(b01, n, 0.5).pvalue if n > 0 else 1.0
+        results.append(
+            {
+                "model": model,
+                "a": a,
+                "b": b,
+                "b_a_wrong_b_right": b01,
+                "b_a_right_b_wrong": b10,
+                "p_value": p,
+            }
+        )
+    return results
+
+
+def load_rows(path: Path) -> list[dict]:
+    return [
+        json.loads(line) for line in Path(path).read_text().splitlines() if line.strip()
+    ]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results", default="results/results.jsonl")
+    args = ap.parse_args()
+    rows = load_rows(Path(args.results))
+
+    print("\n=== mean F1 / exact-rate by model × rendering × stratum ===")
+    for r in aggregate(rows):
+        print(
+            f"{r['model']:<32} {r['rendering']:<13} {r['stratum']:<4} "
+            f"n={r['n']:<4} F1={r['mean_f1']:.3f} exact={r['exact_rate']:.3f}"
+        )
+
+    print("\n=== paired McNemar (exact-match) ===")
+    for model in sorted({r["model"] for r in rows}):
+        for res in mcnemar_pairs(rows, model):
+            print(
+                f"{model:<32} {res['a']} vs {res['b']}: "
+                f"disc {res['b_a_wrong_b_right']}/{res['b_a_right_b_wrong']} "
+                f"p={res['p_value']:.4f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/mermaid-joinpath-eval/pyproject.toml
+++ b/experiments/mermaid-joinpath-eval/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "mje"
+version = "0.1.0"
+description = "Mermaid vs text rendering for LLM join-path reasoning (anonymized Spider)"
+requires-python = ">=3.12"
+dependencies = [
+    "sqlglot>=25",
+    "openai>=1.40",
+    "requests>=2.31",
+    "scipy>=1.11",
+]
+
+[dependency-groups]
+dev = ["pytest>=8"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/experiments/mermaid-joinpath-eval/tests/fixtures/bird_mini/dev.json
+++ b/experiments/mermaid-joinpath-eval/tests/fixtures/bird_mini/dev.json
@@ -1,0 +1,6 @@
+[
+  {"db_id": "shop", "question": "q", "evidence": "", "difficulty": "moderate",
+   "SQL": "SELECT c.name FROM customers c, orders o, line_items l WHERE c.id = o.customer_id AND o.id = l.order_id"},
+  {"db_id": "shop", "question": "q", "evidence": "", "difficulty": "simple",
+   "SQL": "SELECT name FROM customers"}
+]

--- a/experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/dev.json
+++ b/experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/dev.json
@@ -1,0 +1,8 @@
+[
+  {"db_id": "shop", "question": "ignored",
+   "query": "SELECT T1.name FROM customers AS T1 JOIN orders AS T2 ON T1.id = T2.customer_id"},
+  {"db_id": "shop", "question": "ignored",
+   "query": "SELECT c.name FROM customers c, orders o, line_items l WHERE c.id = o.customer_id AND o.id = l.order_id"},
+  {"db_id": "shop", "question": "ignored",
+   "query": "SELECT name FROM customers"}
+]

--- a/experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/tables.json
+++ b/experiments/mermaid-joinpath-eval/tests/fixtures/spider_mini/tables.json
@@ -1,0 +1,15 @@
+[
+  {
+    "db_id": "shop",
+    "table_names_original": ["customers", "orders", "line_items", "products"],
+    "column_names_original": [
+      [-1, "*"],
+      [0, "id"], [0, "name"],
+      [1, "id"], [1, "customer_id"],
+      [2, "id"], [2, "order_id"], [2, "product_id"],
+      [3, "id"], [3, "title"]
+    ],
+    "column_types": ["text", "number", "text", "number", "number", "number", "number", "number", "number", "text"],
+    "foreign_keys": [[4, 1], [6, 3], [7, 8]]
+  }
+]

--- a/experiments/mermaid-joinpath-eval/tests/test_anonymize.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_anonymize.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+from mje.anonymize import anonymize, map_edges, map_tables
+from mje.schema_graph import edge_key, parse_tables_json
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _shop():
+    return parse_tables_json(json.loads(FIX.read_text())[0])
+
+
+def test_anonymize_renames_tables_and_columns_opaquely():
+    g = _shop()
+    ag, m = anonymize(g)
+    assert set(ag.tables) == {"t0", "t1", "t2", "t3"}
+    blob = " ".join(
+        [t for t in ag.tables] + [c.name for cols in ag.tables.values() for c in cols]
+    )
+    for original in [
+        "customers",
+        "orders",
+        "line_items",
+        "products",
+        "customer_id",
+        "title",
+    ]:
+        assert original not in blob
+    assert {c.type for c in ag.tables["t0"]} <= {"text", "number"}
+
+
+def test_mapping_is_consistent_across_graph_and_edges():
+    g = _shop()
+    ag, m = anonymize(g)
+    gold = {edge_key(("orders", "customer_id"), ("customers", "id"))}
+    mapped = map_edges(gold, m)
+    (pair,) = mapped
+    for tname, cname in pair:
+        assert tname in ag.tables
+        assert cname in {c.name for c in ag.tables[tname]}
+
+
+def test_map_tables():
+    g = _shop()
+    ag, m = anonymize(g)
+    assert map_tables({"customers", "line_items"}, m) == {
+        m.table["customers"],
+        m.table["line_items"],
+    }

--- a/experiments/mermaid-joinpath-eval/tests/test_data.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_data.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from mje.data import build_items
+
+FIXDIR = Path(__file__).parent / "fixtures" / "spider_mini"
+
+
+def test_build_items_filters_by_min_joins_and_anonymizes():
+    items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=2)
+    assert len(items) == 1
+    it = items[0]
+    assert it.n_joins == 2
+    assert all(t.startswith("t") for t in it.endpoint_tables)
+    for pair in it.gold_edges:
+        for tname, cname in pair:
+            assert tname in it.graph.tables
+            assert cname in {c.name for c in it.graph.tables[tname]}
+
+
+def test_min_joins_one_keeps_more():
+    items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=1)
+    assert len(items) == 2  # the no-join query is still dropped
+
+
+def test_ambiguity_flag_present():
+    items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=2)
+    assert isinstance(items[0].ambiguous, bool)
+    assert items[0].ambiguous is False

--- a/experiments/mermaid-joinpath-eval/tests/test_data.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_data.py
@@ -26,3 +26,15 @@ def test_ambiguity_flag_present():
     items = build_items(FIXDIR / "tables.json", FIXDIR / "dev.json", min_joins=2)
     assert isinstance(items[0].ambiguous, bool)
     assert items[0].ambiguous is False
+
+
+def test_build_items_bird_query_key():
+    fixdir = Path(__file__).parent / "fixtures"
+    items = build_items(
+        fixdir / "spider_mini" / "tables.json",
+        fixdir / "bird_mini" / "dev.json",
+        min_joins=2,
+        query_key="SQL",
+    )
+    assert len(items) == 1
+    assert items[0].n_joins == 2

--- a/experiments/mermaid-joinpath-eval/tests/test_grade.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_grade.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from mje.anonymize import anonymize
+from mje.grade import parse_pred_edges, score
+from mje.schema_graph import edge_key, parse_tables_json
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _anon():
+    g = parse_tables_json(json.loads(FIX.read_text())[0])
+    ag, _ = anonymize(g)
+    return ag
+
+
+def test_parse_json_array_of_conditions():
+    ag = _anon()
+    text = '```json\n["t1.c1 = t0.c0", "t2.c1 = t1.c0"]\n```'
+    edges = parse_pred_edges(text, ag)
+    assert edge_key(("t1", "c1"), ("t0", "c0")) in edges
+    assert edge_key(("t2", "c1"), ("t1", "c0")) in edges
+
+
+def test_parse_sql_fallback():
+    ag = _anon()
+    text = "SELECT * FROM t0 JOIN t1 ON t0.c0 = t1.c1"
+    edges = parse_pred_edges(text, ag)
+    assert edges == {edge_key(("t0", "c0"), ("t1", "c1"))}
+
+
+def test_score_perfect():
+    ag = _anon()
+    gold = {edge_key(("t0", "c0"), ("t1", "c1"))}
+    pred = {edge_key(("t1", "c1"), ("t0", "c0"))}
+    s = score(pred, gold, ag)
+    assert s["f1"] == 1.0 and s["exact"] is True and s["hallucinated"] == 0
+
+
+def test_score_partial_and_hallucination():
+    ag = _anon()
+    gold = {
+        edge_key(("t0", "c0"), ("t1", "c1")),
+        edge_key(("t1", "c0"), ("t2", "c1")),
+    }
+    pred = {
+        edge_key(("t0", "c0"), ("t1", "c1")),
+        edge_key(("t0", "c1"), ("t3", "c0")),
+    }
+    s = score(pred, gold, ag)
+    assert s["precision"] == 0.5
+    assert s["recall"] == 0.5
+    assert round(s["f1"], 3) == 0.5
+    assert s["exact"] is False
+    assert s["hallucinated"] == 1

--- a/experiments/mermaid-joinpath-eval/tests/test_model_client.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_model_client.py
@@ -1,0 +1,39 @@
+from mje.model_client import PRICING, ModelClient, cost
+
+
+class _FakeResp:
+    def __init__(self):
+        msg = type("M", (), {"content": '["t0.c0 = t1.c1"]'})
+        self.choices = [type("C", (), {"message": msg})]
+        self.usage = type("U", (), {"prompt_tokens": 1000, "completion_tokens": 50})
+
+
+class _FakeChat:
+    def __init__(self):
+        self.completions = self
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        return _FakeResp()
+
+
+class _FakeClient:
+    def __init__(self):
+        self.chat = _FakeChat()
+
+
+def test_cost_uses_pricing_table():
+    c = cost("anthropic/claude-sonnet-4.6", 1_000_000, 1_000_000)
+    p = PRICING["anthropic/claude-sonnet-4.6"]
+    assert round(c, 6) == round(p["in"] + p["out"], 6)
+
+
+def test_client_call_returns_text_and_usage():
+    mc = ModelClient(api_key="x", client=_FakeClient())
+    text, in_tok, out_tok = mc.call(
+        "anthropic/claude-sonnet-4.6",
+        [{"role": "user", "content": "hi"}],
+        max_tokens=256,
+    )
+    assert text == '["t0.c0 = t1.c1"]'
+    assert in_tok == 1000 and out_tok == 50

--- a/experiments/mermaid-joinpath-eval/tests/test_prompt.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_prompt.py
@@ -1,0 +1,11 @@
+from mje.prompt import build_messages
+
+
+def test_build_messages_contains_rendering_and_tables():
+    msgs = build_messages("RENDERING_TEXT", ["t0", "t2", "t5"])
+    assert msgs[0]["role"] == "system"
+    assert msgs[1]["role"] == "user"
+    user = msgs[1]["content"]
+    assert "RENDERING_TEXT" in user
+    assert "t0" in user and "t2" in user and "t5" in user
+    assert "JSON" in user or "json" in user

--- a/experiments/mermaid-joinpath-eval/tests/test_renderers.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_renderers.py
@@ -2,7 +2,12 @@ import json
 from pathlib import Path
 
 from mje.anonymize import anonymize
-from mje.renderers import RENDERERS, render_mermaid, render_xml
+from mje.renderers import (
+    RENDERERS,
+    render_mermaid,
+    render_mermaid_qualified,
+    render_xml,
+)
 from mje.schema_graph import parse_tables_json
 
 FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
@@ -47,3 +52,16 @@ def test_deterministic_output():
     ag = _anon()
     for fn in RENDERERS.values():
         assert fn(ag) == fn(ag)
+
+
+def test_mermaid_qualified_has_table_qualified_labels():
+    ag = _anon()
+    out = render_mermaid_qualified(ag)
+    assert out.strip().startswith("erDiagram")
+    # every edge label fully qualifies both join columns as table.column
+    for e in ag.fk_edges:
+        a = f"{e.a[0]}.{e.a[1]}"
+        b = f"{e.b[0]}.{e.b[1]}"
+        assert (f"{a} = {b}" in out) or (f"{b} = {a}" in out)
+    # and it is registered for selection
+    assert "mermaid_qualified" in RENDERERS

--- a/experiments/mermaid-joinpath-eval/tests/test_renderers.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_renderers.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from mje.anonymize import anonymize
+from mje.renderers import RENDERERS, render_mermaid, render_xml
+from mje.schema_graph import parse_tables_json
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _anon():
+    g = parse_tables_json(json.loads(FIX.read_text())[0])
+    ag, _ = anonymize(g)
+    return ag
+
+
+def test_all_renderers_mention_every_table():
+    ag = _anon()
+    for name, fn in RENDERERS.items():
+        out = fn(ag)
+        for t in ag.tables:
+            assert t in out, f"{name} dropped table {t}"
+
+
+def test_renderers_encode_every_fk_edge():
+    ag = _anon()
+    for name, fn in RENDERERS.items():
+        out = fn(ag)
+        for e in ag.fk_edges:
+            assert e.a[1] in out and e.b[1] in out
+
+
+def test_xml_is_wellformed_enough():
+    ag = _anon()
+    out = render_xml(ag)
+    assert out.count("<table") == len(ag.tables)
+    assert out.count("<rel ") == len(ag.fk_edges)
+
+
+def test_mermaid_has_header():
+    ag = _anon()
+    out = render_mermaid(ag)
+    assert out.strip().startswith("erDiagram")
+
+
+def test_deterministic_output():
+    ag = _anon()
+    for fn in RENDERERS.values():
+        assert fn(ag) == fn(ag)

--- a/experiments/mermaid-joinpath-eval/tests/test_runner.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_runner.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+from mje.anonymize import anonymize, map_edges, map_tables
+from mje.data import Item
+from mje.runner import run_eval
+from mje.schema_graph import extract_gold_edges, gold_tables, parse_tables_json
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini"
+
+
+class _FakeClient:
+    """Always returns the gold edges as a JSON array -> perfect score."""
+
+    def __init__(self, items):
+        self._by_id = {it.item_id: it for it in items}
+
+    def call(self, model, messages, max_tokens=256, retries=3):
+        user = messages[1]["content"]
+        for it in self._by_id.values():
+            if all(t in user for t in it.endpoint_tables):
+                conds = [
+                    f"{tuple(e)[0][0]}.{tuple(e)[0][1]}"
+                    f" = {tuple(e)[1][0]}.{tuple(e)[1][1]}"
+                    for e in it.gold_edges
+                ]
+                return json.dumps(conds), 100, 20
+        return "[]", 100, 20
+
+
+def _one_item():
+    g = parse_tables_json(json.loads((FIX / "tables.json").read_text())[0])
+    q = (
+        "SELECT c.name FROM customers c, orders o, line_items l "
+        "WHERE c.id = o.customer_id AND o.id = l.order_id"
+    )
+    gold = extract_gold_edges(q, g)
+    used = gold_tables(q, g)
+    ag, m = anonymize(g)
+    return Item(
+        "shop-1",
+        "shop",
+        q,
+        ag,
+        map_edges(gold, m),
+        sorted(map_tables(used, m)),
+        2,
+        False,
+    )
+
+
+def test_run_eval_scores_all_renderings(tmp_path):
+    items = [_one_item()]
+    client = _FakeClient(items)
+    out = tmp_path / "results.jsonl"
+    rows = run_eval(
+        items,
+        models=["anthropic/claude-sonnet-4.6"],
+        client=client,
+        out_path=out,
+        max_spend=1.0,
+    )
+    assert len(rows) == 3
+    assert all(r["f1"] == 1.0 and r["exact"] for r in rows)
+    assert {r["rendering"] for r in rows} == {"xml", "mermaid", "nl_adjacency"}
+    assert out.exists() and len(out.read_text().strip().splitlines()) == 3
+
+
+def test_budget_cap_aborts(tmp_path):
+    items = [_one_item()]
+    client = _FakeClient(items)
+    rows = run_eval(
+        items,
+        models=["anthropic/claude-sonnet-4.6"],
+        client=client,
+        out_path=tmp_path / "r.jsonl",
+        max_spend=0.0,
+    )
+    assert rows == []

--- a/experiments/mermaid-joinpath-eval/tests/test_runner.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_runner.py
@@ -62,10 +62,30 @@ def test_run_eval_scores_all_renderings(tmp_path):
         out_path=out,
         max_spend=1.0,
     )
-    assert len(rows) == 3
+    from mje.renderers import RENDERERS
+
+    assert len(rows) == len(RENDERERS)
     assert all(r["f1"] == 1.0 and r["exact"] for r in rows)
-    assert {r["rendering"] for r in rows} == {"xml", "mermaid", "nl_adjacency"}
-    assert out.exists() and len(out.read_text().strip().splitlines()) == 3
+    assert {r["rendering"] for r in rows} == set(RENDERERS)
+    assert out.exists() and len(out.read_text().strip().splitlines()) == len(RENDERERS)
+
+
+def test_run_eval_respects_renderings_subset(tmp_path):
+    from mje.renderers import RENDERERS
+
+    items = [_one_item()]
+    client = _FakeClient(items)
+    subset = {"mermaid_qualified": RENDERERS["mermaid_qualified"]}
+    rows = run_eval(
+        items,
+        models=["anthropic/claude-sonnet-4.6"],
+        client=client,
+        out_path=tmp_path / "r.jsonl",
+        max_spend=1.0,
+        renderings=subset,
+    )
+    assert len(rows) == 1
+    assert {r["rendering"] for r in rows} == {"mermaid_qualified"}
 
 
 def test_main_rejects_unknown_model(monkeypatch):

--- a/experiments/mermaid-joinpath-eval/tests/test_runner.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_runner.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+from mje import runner
 from mje.anonymize import anonymize, map_edges, map_tables
 from mje.data import Item
 from mje.runner import run_eval
@@ -64,6 +66,18 @@ def test_run_eval_scores_all_renderings(tmp_path):
     assert all(r["f1"] == 1.0 and r["exact"] for r in rows)
     assert {r["rendering"] for r in rows} == {"xml", "mermaid", "nl_adjacency"}
     assert out.exists() and len(out.read_text().strip().splitlines()) == 3
+
+
+def test_main_rejects_unknown_model(monkeypatch):
+    import sys
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mje.runner", "--models", "fake/model", "--tables", "x", "--dev", "y"],
+    )
+    with pytest.raises(SystemExit):
+        runner.main()
 
 
 def test_budget_cap_aborts(tmp_path):

--- a/experiments/mermaid-joinpath-eval/tests/test_schema_graph.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_schema_graph.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+
+from mje.schema_graph import (
+    SchemaGraph,
+    edge_key,
+    extract_gold_edges,
+    gold_tables,
+    parse_tables_json,
+)
+
+FIX = Path(__file__).parent / "fixtures" / "spider_mini" / "tables.json"
+
+
+def _shop() -> SchemaGraph:
+    entry = json.loads(FIX.read_text())[0]
+    return parse_tables_json(entry)
+
+
+def test_parse_tables_json_builds_tables_and_columns():
+    g = _shop()
+    assert g.db_id == "shop"
+    assert set(g.tables) == {"customers", "orders", "line_items", "products"}
+    cols = {c.name for c in g.tables["orders"]}
+    assert cols == {"id", "customer_id"}
+    assert all(c.name != "*" for t in g.tables.values() for c in t)
+
+
+def test_parse_tables_json_builds_fk_edges():
+    g = _shop()
+    keys = {edge_key(e.a, e.b) for e in g.fk_edges}
+    assert edge_key(("orders", "customer_id"), ("customers", "id")) in keys
+    assert edge_key(("line_items", "order_id"), ("orders", "id")) in keys
+    assert edge_key(("line_items", "product_id"), ("products", "id")) in keys
+    assert len(g.fk_edges) == 3
+
+
+def test_extract_gold_edges_resolves_aliases_and_where_joins():
+    g = _shop()
+    q1 = (
+        "SELECT T1.name FROM customers AS T1 JOIN orders AS T2 "
+        "ON T1.id = T2.customer_id"
+    )
+    e1 = extract_gold_edges(q1, g)
+    assert e1 == {edge_key(("customers", "id"), ("orders", "customer_id"))}
+
+    q2 = (
+        "SELECT c.name FROM customers c, orders o, line_items l "
+        "WHERE c.id = o.customer_id AND o.id = l.order_id"
+    )
+    e2 = extract_gold_edges(q2, g)
+    assert e2 == {
+        edge_key(("customers", "id"), ("orders", "customer_id")),
+        edge_key(("orders", "id"), ("line_items", "order_id")),
+    }
+
+
+def test_extract_gold_edges_qualifies_unqualified_columns():
+    g = _shop()
+    q = "SELECT title FROM line_items JOIN products ON product_id = products.id"
+    e = extract_gold_edges(q, g)
+    assert e == {edge_key(("line_items", "product_id"), ("products", "id"))}
+
+
+def test_gold_tables_returns_from_join_tables():
+    g = _shop()
+    q = (
+        "SELECT c.name FROM customers c JOIN orders o ON c.id = o.customer_id "
+        "JOIN line_items l ON o.id = l.order_id"
+    )
+    assert gold_tables(q, g) == {"customers", "orders", "line_items"}

--- a/experiments/mermaid-joinpath-eval/tests/test_stats.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_stats.py
@@ -1,0 +1,65 @@
+from mje.stats import aggregate, mcnemar_pairs
+
+
+def _rows():
+    return [
+        {
+            "item_id": "a",
+            "model": "M",
+            "rendering": "xml",
+            "n_joins": 2,
+            "ambiguous": False,
+            "f1": 1.0,
+            "exact": True,
+        },
+        {
+            "item_id": "a",
+            "model": "M",
+            "rendering": "mermaid",
+            "n_joins": 2,
+            "ambiguous": False,
+            "f1": 1.0,
+            "exact": True,
+        },
+        {
+            "item_id": "b",
+            "model": "M",
+            "rendering": "xml",
+            "n_joins": 3,
+            "ambiguous": False,
+            "f1": 0.0,
+            "exact": False,
+        },
+        {
+            "item_id": "b",
+            "model": "M",
+            "rendering": "mermaid",
+            "n_joins": 3,
+            "ambiguous": False,
+            "f1": 1.0,
+            "exact": True,
+        },
+    ]
+
+
+def test_aggregate_means_by_group():
+    agg = aggregate(_rows())
+    xml = [
+        r
+        for r in agg
+        if r["model"] == "M" and r["rendering"] == "xml" and r["stratum"] == "all"
+    ][0]
+    mer = [
+        r
+        for r in agg
+        if r["model"] == "M" and r["rendering"] == "mermaid" and r["stratum"] == "all"
+    ][0]
+    assert xml["mean_f1"] == 0.5
+    assert mer["mean_f1"] == 1.0
+
+
+def test_mcnemar_returns_pvalue():
+    res = mcnemar_pairs(_rows(), model="M")
+    pair = [r for r in res if {r["a"], r["b"]} == {"xml", "mermaid"}][0]
+    assert "p_value" in pair and 0.0 <= pair["p_value"] <= 1.0
+    assert pair["b_a_wrong_b_right"] == 1

--- a/experiments/mermaid-joinpath-eval/tests/test_stats.py
+++ b/experiments/mermaid-joinpath-eval/tests/test_stats.py
@@ -1,44 +1,36 @@
 from mje.stats import aggregate, mcnemar_pairs
 
 
+def _row(
+    item,
+    rendering,
+    *,
+    n_joins=2,
+    ambiguous=False,
+    f1=1.0,
+    exact=True,
+    truncated=False,
+    pred_edges=(("t.a", "t.b"),),
+):
+    return {
+        "item_id": item,
+        "model": "M",
+        "rendering": rendering,
+        "n_joins": n_joins,
+        "ambiguous": ambiguous,
+        "f1": f1,
+        "exact": exact,
+        "truncated": truncated,
+        "pred_edges": [list(e) for e in pred_edges],
+    }
+
+
 def _rows():
     return [
-        {
-            "item_id": "a",
-            "model": "M",
-            "rendering": "xml",
-            "n_joins": 2,
-            "ambiguous": False,
-            "f1": 1.0,
-            "exact": True,
-        },
-        {
-            "item_id": "a",
-            "model": "M",
-            "rendering": "mermaid",
-            "n_joins": 2,
-            "ambiguous": False,
-            "f1": 1.0,
-            "exact": True,
-        },
-        {
-            "item_id": "b",
-            "model": "M",
-            "rendering": "xml",
-            "n_joins": 3,
-            "ambiguous": False,
-            "f1": 0.0,
-            "exact": False,
-        },
-        {
-            "item_id": "b",
-            "model": "M",
-            "rendering": "mermaid",
-            "n_joins": 3,
-            "ambiguous": False,
-            "f1": 1.0,
-            "exact": True,
-        },
+        _row("a", "xml", n_joins=2, f1=1.0, exact=True),
+        _row("a", "mermaid", n_joins=2, f1=1.0, exact=True),
+        _row("b", "xml", n_joins=3, f1=0.0, exact=False),
+        _row("b", "mermaid", n_joins=3, f1=1.0, exact=True),
     ]
 
 
@@ -62,4 +54,85 @@ def test_mcnemar_returns_pvalue():
     res = mcnemar_pairs(_rows(), model="M")
     pair = [r for r in res if {r["a"], r["b"]} == {"xml", "mermaid"}][0]
     assert "p_value" in pair and 0.0 <= pair["p_value"] <= 1.0
-    assert pair["b_a_wrong_b_right"] == 1
+
+
+def test_mcnemar_keys_are_self_describing():
+    # item b: xml wrong, mermaid right -> the discordant count must be attributed
+    # to whichever of a/b is mermaid, not to a fixed positional slot.
+    res = mcnemar_pairs(_rows(), model="M")
+    pair = [r for r in res if {r["a"], r["b"]} == {"xml", "mermaid"}][0]
+    wins = {pair["a"]: pair["a_right_b_wrong"], pair["b"]: pair["b_right_a_wrong"]}
+    assert wins["mermaid"] == 1
+    assert wins["xml"] == 0
+
+
+def test_aggregate_reports_parse_failure_and_truncated_rates():
+    rows = [
+        _row("a", "xml", f1=0.0, exact=False, pred_edges=()),  # parse failure
+        _row("b", "xml", f1=1.0, exact=True, truncated=True),  # truncated
+    ]
+    g = [r for r in aggregate(rows) if r["stratum"] == "all"][0]
+    assert g["parse_fail_rate"] == 0.5
+    assert g["truncated_rate"] == 0.5
+
+
+def test_aggregate_stratifies_by_ambiguity():
+    rows = [
+        _row("a", "xml", ambiguous=True, f1=0.4, exact=False),
+        _row("b", "xml", ambiguous=False, f1=0.8, exact=True),
+    ]
+    by = {r["stratum"]: r for r in aggregate(rows) if r["rendering"] == "xml"}
+    assert by["ambig"]["mean_f1"] == 0.4 and by["ambig"]["n"] == 1
+    assert by["unambig"]["mean_f1"] == 0.8 and by["unambig"]["n"] == 1
+    assert by["all"]["n"] == 2
+
+
+def test_aggregate_exclude_truncated_changes_mean():
+    rows = [
+        _row("a", "xml", f1=1.0, exact=True, truncated=False),
+        _row("b", "xml", f1=0.0, exact=False, truncated=True),
+    ]
+    incl = [r for r in aggregate(rows) if r["stratum"] == "all"][0]
+    excl = [
+        r for r in aggregate(rows, exclude_truncated=True) if r["stratum"] == "all"
+    ][0]
+    assert incl["mean_f1"] == 0.5 and incl["n"] == 2
+    assert excl["mean_f1"] == 1.0 and excl["n"] == 1
+
+
+def test_mcnemar_unambiguous_only_drops_ambiguous_items():
+    rows = [
+        # ambiguous discordant pair (xml right, mermaid wrong)
+        _row("a", "xml", ambiguous=True, exact=True),
+        _row("a", "mermaid", ambiguous=True, exact=False),
+        # unambiguous concordant pair (both right)
+        _row("b", "xml", ambiguous=False, exact=True),
+        _row("b", "mermaid", ambiguous=False, exact=True),
+    ]
+    full = [
+        r for r in mcnemar_pairs(rows, "M") if {r["a"], r["b"]} == {"xml", "mermaid"}
+    ][0]
+    unamb = [
+        r
+        for r in mcnemar_pairs(rows, "M", ambiguity="unambig")
+        if {r["a"], r["b"]} == {"xml", "mermaid"}
+    ][0]
+    assert full["a_right_b_wrong"] + full["b_right_a_wrong"] == 1  # the ambig pair
+    assert unamb["a_right_b_wrong"] + unamb["b_right_a_wrong"] == 0  # dropped
+
+
+def test_mcnemar_exclude_truncated_drops_pair():
+    rows = [
+        _row("a", "xml", exact=True, truncated=False),
+        _row("a", "mermaid", exact=False, truncated=True),  # truncated -> drop pair
+    ]
+    full = [
+        r for r in mcnemar_pairs(rows, "M") if {r["a"], r["b"]} == {"xml", "mermaid"}
+    ][0]
+    clean = [
+        r
+        for r in mcnemar_pairs(rows, "M", exclude_truncated=True)
+        if {r["a"], r["b"]} == {"xml", "mermaid"}
+    ][0]
+    assert full["a_right_b_wrong"] + full["b_right_a_wrong"] == 1
+    assert clean["a_right_b_wrong"] + clean["b_right_a_wrong"] == 0

--- a/experiments/mermaid-joinpath-eval/uv.lock
+++ b/experiments/mermaid-joinpath-eval/uv.lock
@@ -1,0 +1,628 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "mje"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "openai" },
+    { name = "requests" },
+    { name = "scipy" },
+    { name = "sqlglot" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "openai", specifier = ">=1.40" },
+    { name = "requests", specifier = ">=2.31" },
+    { name = "scipy", specifier = ">=1.11" },
+    { name = "sqlglot", specifier = ">=25" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/1d/b1380b3ee8fb63c50d7507e956a1228ddefff1a2601d79806c998ef6547b/sqlglot-30.9.0.tar.gz", hash = "sha256:20bed04b6482bf13560206cae517f451f46c321e04956ad71271ed1f12ce8802", size = 5885862, upload-time = "2026-06-04T15:33:52.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/4c/41b222c130950a077e1a0ba311df84a29b818db7c136ecc1aafbfad42e26/sqlglot-30.9.0-py3-none-any.whl", hash = "sha256:59b5f74f4d391e32e6980e8cd23cca8d47beac3c0140b711ead9ed05a824a8b5", size = 695762, upload-time = "2026-06-04T15:33:49.526Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/b3/36c8ecf72e8925200671613332db156d84b99b3aee742a41c1938ebb0808/tqdm-4.68.1.tar.gz", hash = "sha256:fc163d96b287bd031e1aa24421ce4411b25559bd0a1be4fe649bdaa4d2c02bf5", size = 171236, upload-time = "2026-06-05T17:23:15.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/aa/218a0eb34de1f753c83e4d0d1c8e7c4cef27f20dcb8342e024f63a80dc86/tqdm-4.68.1-py3-none-any.whl", hash = "sha256:fea4a90e4023f764914569f7802a297277c5ab1a66be5144143e142e1a4031d8", size = 78354, upload-time = "2026-06-05T17:23:13.654Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
## Summary

A self-contained empirical experiment (under `experiments/mermaid-joinpath-eval/`, fully decoupled from the library) testing whether rendering table relationships as **Mermaid** is a better "memory carrier" for an LLM than the library's current **XML** rendering — measured by join-path reconstruction accuracy.

**Result: No.** Mermaid is at best tied-within-noise and at worst significantly *worse*. XML and natural-language adjacency are equivalent and best. **Keep the existing XML relationship rendering** (`core/prompt.py::_render_relationships`).

- Raw Mermaid is **significantly worse** than XML on both models (McNemar p=0.013 Sonnet 4.6 / p=0.001 DeepSeek V4 Flash).
- ~half that deficit was a renderer-design flaw (under-qualified edge labels), isolated via a `mermaid_qualified` arm — recovers to "tied, trending worse."
- A residual deficit remains even with fully-qualified labels.

Why this PR exists: it is the **audit trail** for the XML-vs-Mermaid design decision. The harness, datasets-on-demand, McNemar p-values, and reproduction commands all live here so the "why not Mermaid?" question has a citable answer.

## What's included

- `mje/` — schema-graph parsing, opaque-token anonymization (contamination control), 4 information-equivalent renderers, single-shot reconstruction prompt, static edge grading, OpenRouter client, budget-capped runner, paired-McNemar stats.
- `FINDINGS.md` — full writeup: method, headline results, conclusion, methodological catches, limitations, reproduction.
- `docs/superpowers/specs/` + `docs/superpowers/plans/` — committed design spec and TDD plan.
- 31 tests; `data/` and `results/` gitignored (datasets downloaded on demand, result JSONL never committed).

## Methodological notes worth a reviewer's eye

- **Reasoning-token truncation trap:** the first smoke showed a dramatic but *entirely artifactual* "XML collapses" effect — `max_tokens=256` was consumed by DeepSeek's hidden reasoning. Fixed (default 4096 + log `raw`/`truncated`). A wrong conclusion was one careless run away.
- **Contamination:** both Spider and BIRD predate the model cutoffs, biasing a naive A/B toward a false null; opaque-token anonymization is the decontamination strategy.
- **Scope honesty:** n=98 BIRD items, 2 models, single-sample temp 0. Directional and decision-grade, not definitive-at-scale.

## Test Plan

- [x] `cd experiments/mermaid-joinpath-eval && uv run pytest -q` → 31 passed
- [ ] (optional) reproduce live results per `FINDINGS.md` (requires `OPENROUTER_API_KEY`, ~$1.6 spend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)