### PR TITLE
chore: adopt the official ty pre-commit hook, fix the bug it found

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # The hook revs in .pre-commit-config.yaml are the only place ruff's and ty's
+  # versions are declared -- the lint job runs the hooks rather than the tools --
+  # so bumping a rev here moves CI and every developer's pre-commit in lockstep.
+  # Dependabot skips `local` hooks, which is why these must stay as real repos.
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    groups:
+      hooks:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,13 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
       - run: uv python install 3.13
+      # Not a lint step: `--frozen` fails if uv.lock has drifted from pyproject.
       - run: uv sync --all-extras --dev --frozen
-      - run: uv run ruff check src/ tests/
-      - run: uv run ruff format --check src/ tests/
-      # Same ty version the prek hook pins, so a commit that passes the hooks
-      # locally cannot fail here on a version drift.
-      - run: uvx ty@0.0.58 check
+      # Run the hooks themselves instead of re-invoking ruff and ty, so the revs
+      # in .pre-commit-config.yaml are the single source of truth for which tool
+      # versions run. A version named here too would be a copy Dependabot cannot
+      # see, and it would silently drift from the hook on the next bump.
+      - run: uvx prek run --all-files --show-diff-on-failure
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - run: uv sync --all-extras --dev --frozen
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
+      # Same ty version the prek hook pins, so a commit that passes the hooks
+      # locally cannot fail here on a version drift.
+      - run: uvx ty@0.0.58 check
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: local
+  # The rev pins both the ty version and a compatible uv version. The hook runs
+  # `uv check` under the hood, so this project's own dependencies resolve for ty
+  # -- a `language: system` hook calling `ty check` cannot see them, and needs
+  # `unresolved-import = "ignore"` to stay quiet.
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.58
     hooks:
-      - id: ty-check
-        name: ty check
-        entry: ty check
-        language: system
-        types: [python]
-        pass_filenames: false
+      - id: ty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,5 +107,10 @@ override-dependencies = [
 [tool.ty.environment]
 python-version = "3.12"
 
-[tool.ty.rules]
-unresolved-import = "ignore"
+[tool.ty.src]
+# `experiments/` is a standalone project with its own pyproject.toml, lockfile,
+# and venv (openai, scipy). Resolving its imports against the root venv would
+# fail, so it is checked from its own directory, not from here. Scoping ty out
+# of it is what lets the root project keep `unresolved-import` at error level --
+# a typo'd import in src/ must not pass.
+exclude = ["experiments/"]

--- a/src/agentic_data_contracts/core/principal.py
+++ b/src/agentic_data_contracts/core/principal.py
@@ -30,12 +30,12 @@ def resolve_principal(p: Principal) -> str | None:
     """
     if p is None:
         return None
-    if callable(p):
-        # ty can't narrow `p` after the `callable()` guard when Principal
-        # is a union including str; the call is safe because the guard
-        # above confirmed p is a Callable.
-        return p()  # ty: ignore[call-top-callable]
-    return p
+    # Narrow by excluding `str` rather than testing `callable()`: a `callable()`
+    # guard over a union containing `str` widens to a top callable, whose return
+    # type is `object`, not `str | None`.
+    if isinstance(p, str):
+        return p
+    return p()
 
 
 def principal_in_scope(


### PR DESCRIPTION
## Why

The `ty` hook was a `repo: local` entry running `ty check` with `language: system` — it type checked with **whatever `ty` was on the developer's PATH** (on my machine: 0.0.26, from March), or errored out entirely if `ty` wasn't installed. No version contract, and — being `local` — nothing Dependabot could ever bump.

The config also carried a repo-wide `unresolved-import = "ignore"`. That suppression was really there to keep `experiments/` quiet (a standalone project with its own lockfile and venv), but its blast radius was the whole repo, so a **typo'd import in `src/` type checked clean**:

```console
$ echo 'from sqlgot import parse_one' > src/agentic_data_contracts/_typo_probe.py

# old config
$ uvx ty check --ignore unresolved-import
All checks passed!

# new config
$ uvx ty check
error[unresolved-import]: Cannot resolve imported module `sqlgot`
```

## What

**1. Adopt [`astral-sh/ty-pre-commit`](https://github.com/astral-sh/ty-pre-commit) `v0.0.58`.** The `rev` pins both ty and a compatible uv, and the hook runs uv's preview `uv check` under the hood, so the project's dependencies resolve for ty. Being a real repo rather than a `local` hook is also what makes it *updatable* — see (4).

**2. Replace the blanket suppression with a targeted exclusion.** `experiments/` is scoped out via `[tool.ty.src] exclude` — it is checked from its own directory, not this one. `unresolved-import` stays at **error** level for `src/` and `tests/`.

**3. Fix the real type error this surfaced.** `resolve_principal()` guarded with `callable(p)` over a union containing `str`, which widens to a *top callable* whose return type is `object` — so a function annotated `-> str | None` could hand back `object`. Narrowing by excluding `str` instead resolves it cleanly:

```python
if p is None:
    return None
if isinstance(p, str):
    return p
return p()          # p is now Callable[[], str | None]
```

The `# ty: ignore[call-top-callable]` comment is gone — it was treating the symptom. No behavior change: no caller passes a value outside the `Principal` type, and the existing tests (`None`, `str`, `""`, `lambda → str`, `lambda → None`, `lambda → ""`, raising callable) all pass unchanged.

**4. Give the version one home, and let Dependabot own it.** Hooks can be skipped with `--no-verify` — this bug reached `main` because nothing checked types server-side — so CI has to run them too. But *naming a version in CI* would be a copy, not a declaration: ty-pre-commit bakes `--ty-version` into its manifest entry at each tag, so `rev` is the only real source, and a CI-side `uvx ty@0.0.58` is a hand-maintained mirror of a constant living in someone else's repo. Nothing can keep those in sync.

So the `lint` job runs the hooks themselves (`uvx prek run --all-files`) instead of re-invoking the tools. `.pre-commit-config.yaml` becomes the single source of truth for which ruff and ty actually execute, CI and local pre-commit run identical builds, and there is exactly one number to bump — which [Dependabot's pre-commit ecosystem](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/) (added March 2026) now owns. It skips `local` hooks, so this only works because of (1).

This also closes a latent drift of the same kind: ruff's version reached CI via `uv.lock` (`ruff>=0.15.10`, unbounded) but reached the hook via `rev: v0.15.20` — equal today only by luck, and the next bump would have split them.

## Verification

- `prek run --all-files` — ruff-check, ruff-format, ty all pass, with `unresolved-import` at error level.
- The same command **exits 1** on a planted typo'd import in `src/` — the new lint step can still go red.
- `uv run pytest` — **688 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)