### PR TITLE
Fix dump_semantic_source empty-key emission + example decompositions (v0.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Docs
 
 - The `revenue_agent` and `growth_agent` examples now demonstrate the 0.28.0 feature. `revenue_agent` declares a `product` identity (`total_revenue = active_customers × revenue_per_customer`) plus a `region` drill dimension; `growth_agent` declares a `ratio` identity on `conversion_rate` which — combined with its existing causal impact edge — exercises a *mixed* identity + influence graph, the case `trace_metric_impacts`'s `kinds` filter is built for.
+- Filled decomposition gaps left in `docs/architecture.md` by the 0.28.0 doc pass: the 9-tools list now shows `trace_metric_impacts`'s `kinds` argument and its dual-edge-kind walk, `lookup_metric` notes the surfaced `decompositions` / `drill_by`, and the `MetricDefinition` field enumeration includes both new fields.
 
 ## [0.28.0] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.1] - 2026-07-19
+
+### Fixed
+
+- **`dump_semantic_source` now omits empty `decompositions` / `drill_by`.** 0.28.0 emitted both keys on *every* metric even when empty, which (a) diverged from the omit-when-empty convention the tools layer already uses (`_metric_details`) and (b) changed a frozen contract's `contract_digest` for a source that declares no decompositions — re-freezing a pre-0.28 contract produced a different content address than it had under 0.27.x. A leaf metric now dumps byte-identically to the pre-0.28 format, so `contract_digest` is stable across the upgrade for contracts that don't use the new fields. Metrics that *do* declare decompositions/drill_by are unaffected (the keys are still emitted and round-trip through `from_raw`).
+
+### Docs
+
+- The `revenue_agent` and `growth_agent` examples now demonstrate the 0.28.0 feature. `revenue_agent` declares a `product` identity (`total_revenue = active_customers × revenue_per_customer`) plus a `region` drill dimension; `growth_agent` declares a `ratio` identity on `conversion_rate` which — combined with its existing causal impact edge — exercises a *mixed* identity + influence graph, the case `trace_metric_impacts`'s `kinds` filter is built for.
+
 ## [0.28.0] - 2026-07-19
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -350,10 +350,10 @@ Two modes: tool factory for quick starts, middleware for BYO tools.
 1. **`describe_table(schema, table)`** — Column details, merging the database adapter's catalog view with authored descriptions from the semantic source (semantic wins; adapter fills gaps)
 2. **`preview_table(schema, table, limit?)`** — Sample rows
 3. **`list_metrics(domain?, tier?, indicator_kind?)`** — Browse metrics with filters
-4. **`lookup_metric(metric_name)`** — Full metric definition with SQL and impact edges
+4. **`lookup_metric(metric_name)`** — Full metric definition with SQL, impact edges, and any `decompositions` / `drill_by`
 5. **`lookup_domain(name)`** — Full domain description with metrics and tables
 6. **`lookup_relationships(table, target_table?)`** — Direct joins and multi-hop paths
-7. **`trace_metric_impacts(metric_name, direction, max_depth?)`** — BFS over the impact graph
+7. **`trace_metric_impacts(metric_name, direction, max_depth?, kinds?)`** — BFS over the metric graph across both influence and identity (decomposition) edges; `kinds` (`all` / `identity` / `influence`) filters which kind(s) to walk
 8. **`inspect_query(sql)`** — Static + EXPLAIN check, no execution
 9. **`run_query(sql)`** — Validate and execute; response includes remaining session budget
 
@@ -504,7 +504,7 @@ class SemanticSource(Protocol):
 | `CubeSource` | Cube meta API or schema files | Metrics (+ `meta.tier` / `meta.indicator_kind` / `meta.domains`), dimensions |
 | `YamlSource` | Inline YAML definitions | Metric / table / relationship / `metric_impacts` definitions for teams not using dbt/Cube |
 
-`MetricDefinition`: `name`, `description`, `sql_expression`, `source_model`, `filters`, `domains`, `tier`, `indicator_kind`, `business_owner`, `operational_owner`, `last_reviewed`. The last three are parsed by `YamlSource` only; `DbtSource` / `CubeSource` leave them unset.
+`MetricDefinition`: `name`, `description`, `sql_expression`, `source_model`, `filters`, `domains`, `tier`, `indicator_kind`, `business_owner`, `operational_owner`, `last_reviewed`, `decompositions`, `drill_by`. `business_owner` / `operational_owner` / `last_reviewed` and `decompositions` / `drill_by` are parsed by `YamlSource` only; `DbtSource` / `CubeSource` leave them unset/empty.
 `MetricImpact`: `from_metric`, `to_metric`, `direction`, `confidence`, `evidence`, `description`.
 `Decomposition`: `operator`, `operands`. `DrillDimension`: `dimension`, `column`. `IdentityEdge`: `from_metric`, `to_metric`, `operator`.
 `Relationship`: `from_`, `to`, `type`, `description`, `required_filter`, `preferred`. The `preferred` flag (default `False`) marks the canonical join when alternatives exist between the same table pair. `build_relationship_index` stable-sorts each adjacency list with preferred edges first, so `find_join_path` (BFS) and `get_relationships_for_table` both surface the canonical edge automatically. The flat list returned by `get_relationships()` deliberately keeps declaration order; that list feeds the prompt renderer, which renders `preferred="true"` as a per-edge attribute instead of via reordering.

--- a/examples/growth_agent/semantic.yml
+++ b/examples/growth_agent/semantic.yml
@@ -49,6 +49,17 @@ metrics:
     business_owner: growth-analytics
     operational_owner: data-eng-growth
     last_reviewed: 2026-05-15
+    # Arithmetic identity: conversion_rate is exactly first_purchase_users /
+    # cohort_signups. Combined with the causal impact edge below
+    # (activation_rate -> conversion_rate), trace_metric_impacts on this metric
+    # returns a MIXED graph — walk kinds="identity" first (what arithmetically
+    # moved: numerator or denominator?), then kinds="influence" for candidate
+    # causal drivers.
+    decompositions:
+      - operator: ratio
+        operands: [first_purchase_users, cohort_signups]
+    drill_by:
+      - {dimension: acquisition_source, column: analytics.users.acquisition_source}
 
   - name: acquisition_spend
     description: "Total paid-channel spend attributed to acquisition"
@@ -57,6 +68,29 @@ metrics:
     domains: [acquisition]
     tier: [team_kpi]
     indicator_kind: lagging
+    business_owner: growth-analytics
+    operational_owner: data-eng-growth
+    last_reviewed: 2026-05-15
+
+  # Leaf metrics — the numerator and denominator of the conversion_rate ratio.
+  - name: first_purchase_users
+    description: "Distinct users whose first_purchase occurred within 30 days of signup"
+    sql_expression: "COUNT(DISTINCT e.user_id) FILTER (WHERE e.event_name = 'first_purchase')"
+    source_model: analytics.events
+    domains: [experimentation]
+    tier: [team_kpi]
+    indicator_kind: leading
+    business_owner: growth-analytics
+    operational_owner: data-eng-growth
+    last_reviewed: 2026-05-15
+
+  - name: cohort_signups
+    description: "Distinct signed-up users in the cohort (conversion denominator)"
+    sql_expression: "COUNT(DISTINCT u.id)"
+    source_model: analytics.users
+    domains: [acquisition]
+    tier: [team_kpi]
+    indicator_kind: leading
     business_owner: growth-analytics
     operational_owner: data-eng-growth
     last_reviewed: 2026-05-15

--- a/examples/revenue_agent/semantic.yml
+++ b/examples/revenue_agent/semantic.yml
@@ -17,6 +17,16 @@ metrics:
     business_owner: revenue-analytics
     operational_owner: data-eng-finance
     last_reviewed: 2026-05-15
+    # Arithmetic identity (exact, exhaustive): total_revenue is precisely
+    # active_customers × revenue_per_customer. The agent walks this
+    # deterministically for root-cause ("did customer count or per-customer
+    # spend move?") before reaching for the causal impact edges below.
+    decompositions:
+      - operator: product
+        operands: [active_customers, revenue_per_customer]
+    # Priority-ordered dimensional cut the metric can be sliced by exhaustively.
+    drill_by:
+      - {dimension: region, column: analytics.customers.region}
 
   - name: revenue_by_region
     description: "Revenue broken down by customer region"
@@ -38,6 +48,20 @@ metrics:
     domains: [revenue]
     tier: [team_kpi]
     indicator_kind: leading
+    business_owner: revenue-analytics
+    operational_owner: data-eng-finance
+    last_reviewed: 2026-05-15
+
+  # Leaf metric — the second factor of the total_revenue decomposition above.
+  - name: revenue_per_customer
+    description: "Average completed-order revenue per active customer (ARPC)"
+    sql_expression: >
+      SUM(amount) FILTER (WHERE status = 'completed')
+      / NULLIF(COUNT(DISTINCT customer_id) FILTER (WHERE status = 'completed'), 0)
+    source_model: analytics.orders
+    domains: [revenue]
+    tier: [team_kpi]
+    indicator_kind: lagging
     business_owner: revenue-analytics
     operational_owner: data-eng-finance
     last_reviewed: 2026-05-15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.28.0"
+version = "0.28.1"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/semantic/base.py
+++ b/src/agentic_data_contracts/semantic/base.py
@@ -237,6 +237,35 @@ def dump_semantic_source(source: SemanticSource) -> dict[str, Any]:
     def _iso(d: date | None) -> str | None:
         return d.isoformat() if d is not None else None
 
+    def _dump_metric(m: MetricDefinition) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "name": m.name,
+            "description": m.description,
+            "sql_expression": m.sql_expression,
+            "source_model": m.source_model,
+            "filters": list(m.filters),
+            "domains": list(m.domains),
+            "tier": list(m.tier),
+            "indicator_kind": m.indicator_kind,
+            "business_owner": m.business_owner,
+            "operational_owner": m.operational_owner,
+            "last_reviewed": _iso(m.last_reviewed),
+        }
+        # Omit when empty: a leaf metric's dump stays byte-identical to the
+        # pre-0.28 format, so a frozen contract's ``contract_digest`` is stable
+        # across the upgrade, and it matches the omit-when-empty convention the
+        # tools layer already uses (``_metric_details``).
+        if m.decompositions:
+            data["decompositions"] = [
+                {"operator": d.operator, "operands": list(d.operands)}
+                for d in m.decompositions
+            ]
+        if m.drill_by:
+            data["drill_by"] = [
+                {"dimension": dd.dimension, "column": dd.column} for dd in m.drill_by
+            ]
+        return data
+
     tables: list[dict[str, Any]] = []
     for key, ts in source.get_table_schemas().items():
         schema_name, _, table_name = key.partition(".")
@@ -253,30 +282,7 @@ def dump_semantic_source(source: SemanticSource) -> dict[str, Any]:
 
     return {
         "tables": tables,
-        "metrics": [
-            {
-                "name": m.name,
-                "description": m.description,
-                "sql_expression": m.sql_expression,
-                "source_model": m.source_model,
-                "filters": list(m.filters),
-                "domains": list(m.domains),
-                "tier": list(m.tier),
-                "indicator_kind": m.indicator_kind,
-                "business_owner": m.business_owner,
-                "operational_owner": m.operational_owner,
-                "last_reviewed": _iso(m.last_reviewed),
-                "decompositions": [
-                    {"operator": d.operator, "operands": list(d.operands)}
-                    for d in m.decompositions
-                ],
-                "drill_by": [
-                    {"dimension": dd.dimension, "column": dd.column}
-                    for dd in m.drill_by
-                ],
-            }
-            for m in source.get_metrics()
-        ],
+        "metrics": [_dump_metric(m) for m in source.get_metrics()],
         "relationships": [
             {
                 "from": r.from_,

--- a/tests/test_semantic/test_decomposition.py
+++ b/tests/test_semantic/test_decomposition.py
@@ -316,6 +316,42 @@ class TestRoundtrip:
         assert revenue.decompositions[0].operands == ["paying_users", "arpu"]
         assert revenue.drill_by[0].column == "analytics.dim_customer.region"
 
+    def test_dump_omits_empty_decomposition_fields(self) -> None:
+        # A leaf metric (no decompositions/drill_by) must NOT carry empty keys
+        # in the dump — keeps the frozen-contract digest byte-stable against the
+        # pre-0.28 format and matches the tools layer's omit-when-empty rule.
+        source = YamlSource.from_raw(
+            {"metrics": [{"name": "signups", "sql_expression": "COUNT(*)"}]}
+        )
+        metric = dump_semantic_source(source)["metrics"][0]
+        assert "decompositions" not in metric
+        assert "drill_by" not in metric
+
+    def test_dump_includes_nonempty_decomposition_fields(self) -> None:
+        source = YamlSource.from_raw(
+            {
+                "metrics": [
+                    {
+                        "name": "revenue",
+                        "sql_expression": "x",
+                        "decompositions": [
+                            {"operator": "product", "operands": ["a", "b"]}
+                        ],
+                        "drill_by": [{"dimension": "region", "column": "s.t.region"}],
+                    },
+                    {"name": "a", "sql_expression": "x"},
+                    {"name": "b", "sql_expression": "x"},
+                ]
+            }
+        )
+        metric = next(
+            m for m in dump_semantic_source(source)["metrics"] if m["name"] == "revenue"
+        )
+        assert metric["decompositions"] == [
+            {"operator": "product", "operands": ["a", "b"]}
+        ]
+        assert metric["drill_by"] == [{"dimension": "region", "column": "s.t.region"}]
+
 
 from agentic_data_contracts.semantic.base import (  # noqa: E402
     build_metric_impact_index,

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Follow-up patch to v0.28.0.

**Fix:** `dump_semantic_source` emitted `decompositions: []` and `drill_by: []` on *every* metric, even leaves. That (a) diverged from the omit-when-empty convention the tools layer uses (`_metric_details`) and (b) changed a frozen contract's `contract_digest` for a source with no decompositions — re-freezing a pre-0.28 contract yielded a different content address than under 0.27.x. Now a leaf metric dumps byte-identically to the pre-0.28 format, so `contract_digest` is stable across the upgrade for contracts that don't use the new fields. Metrics that *do* declare them are unaffected and still round-trip.

**Examples:** `revenue_agent` now declares a `product` identity (`total_revenue = active_customers × revenue_per_customer`) + a `region` drill; `growth_agent` declares a `ratio` identity on `conversion_rate` that — with its existing causal impact edge — exercises a *mixed* identity+influence graph, the case the `kinds` filter is built for.

## Testing

Two new dump tests (omit-when-empty; non-empty still emitted + round-trips). All three example semantic sources load clean. Full suite 724 passing; `ruff` / `ruff format` / `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)