### PR TITLE
feat: feed token_budget on the create_langchain_tools path (v0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.0] - 2026-08-03
+
+### Added
+
+- **`create_langchain_tools` now feeds `token_budget` itself.** v0.34.0 gave the budget a producer on two of four paths; this closes the third. The `StructuredTool` coroutine declares a `runtime: ToolRuntime | None` parameter, which LangGraph's `ToolNode` injects with the run's message history and thread id — the same material `ContractMiddleware` already read. A declared budget therefore binds on a plain `create_langchain_tools(...)` wiring, with no middleware and no manual `observe_tokens()` call. Verified end-to-end through a real `create_agent`, and at the declared floors (`langchain` 1.2.17 / `langchain-core` 1.3.3 / `langgraph` 1.1.10) — no floor bump was needed.
+
+  Three properties worth knowing, each of which had a way of going wrong:
+
+  - **The model never sees the parameter.** `infer_schema=False` means the advertised schema is the tool's JSON Schema dict verbatim, not the coroutine signature; `tool.args` is unchanged.
+  - **It is optional, defaulting to `None`.** Injection happens inside a graph; `await tool.ainvoke({"sql": ...})` is a supported call shape that passes no runtime. A required parameter would break every direct caller in order to catch a mis-wiring whose worst case is the *previous* behaviour — usage simply unobserved.
+  - **Observation precedes the limit check**, matching the Pydantic AI adapter, so a budget the current run has already blown stops that call rather than the next.
+
+- **The usage accounting is now shared** between `ContractMiddleware` and the tool path (`_observe_usage` / `_usage_scope_for`, keyed on `(state, config)` — the one shape both callers can produce) rather than duplicated. Fed the same run, both derive the same per-conversation scope key and observe the same cumulative total, so **wiring both does not double-count**: whichever runs second is a no-op. That property is what makes the tool-path observation safe to leave unconditional instead of gating it on `apply_middleware`, which governs *enforcement*, not observation. Sharing was the point — a duplicated envelope in `middleware.py` is what let a bug through in v0.32.0, and two copies of a scope derivation could drift into disagreeing about one session's total.
+
+### Removed
+
+- **The wiring-time `token_budget` warning on `create_langchain_tools`**, and with it the `apply_middleware` special case that suppressed it. Both existed only to describe this gap. `contract_middleware` and the Claude Agent SDK path still warn; they receive an `args` dict and nothing else, and remain genuinely blind. The warning's *"does not observe"* wording — chosen over *"cannot"* in v0.34.0 — earned its keep: closing this gap took one parameter declaration, not a new capability.
+
+### Compatibility
+
+- Additive. Existing calls are unchanged, direct `tool.ainvoke({...})` still works, and the advertised tool arguments are unchanged (asserted by test, not assumed). **But a `token_budget` declared alongside `create_langchain_tools` now binds where it previously did not** — a contract carrying an aspirational budget will start raising `ToolException` once it is passed. Raise or remove the value if it was never meant to bind; the v0.34.0 warning was the notice for this.
+- One caveat for the direct-invocation path: outside a graph nothing injects a runtime, so usage still goes unobserved there. This is unchanged behaviour, not a new gap, and is why the parameter is optional.
+
 ## [0.34.0] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 
 - **The wiring-time `token_budget` warning on `create_langchain_tools`**, and with it the `apply_middleware` special case that suppressed it. Both existed only to describe this gap. `contract_middleware` and the Claude Agent SDK path still warn; they receive an `args` dict and nothing else, and remain genuinely blind. The warning's *"does not observe"* wording — chosen over *"cannot"* in v0.34.0 — earned its keep: closing this gap took one parameter declaration, not a new capability.
 
+### Known limitation
+
+- **A nested run under-counts.** A sub-agent or subgraph inherits its parent's `thread_id`, so it collides on the scope key while carrying its own, shorter history — and because `observe_tokens` keeps the larger total per scope, its usage is dropped whole rather than added: a 5000-token parent turn followed by an 800-token sub-agent turn accrues 5000, not 5800. This is not a regression (the tools observed nothing at all before), and it under-enforces rather than over-enforces, but v0.35.0 makes it reachable automatically in `create_deep_agent(tools=tools)`, which is the README's own headline wiring. The obvious fix does not work: the config's `checkpoint_ns` is `tools:<task-id>` and changes on *every* tool call, so keying on it would re-accrue the full total each time and multiply rather than separate. Pinned by `test_nested_run_sharing_a_thread_id_under_counts` so it cannot drift unnoticed.
+
 ### Compatibility
 
 - Additive. Existing calls are unchanged, direct `tool.ainvoke({...})` still works, and the advertised tool arguments are unchanged (asserted by test, not assumed). **But a `token_budget` declared alongside `create_langchain_tools` now binds where it previously did not** — a contract carrying an aspirational budget will start raising `ToolException` once it is passed. Raise or remove the value if it was never meant to bind; the v0.34.0 warning was the notice for this.

--- a/README.md
+++ b/README.md
@@ -928,10 +928,10 @@ remaining paths (`contract_middleware` and the Claude Agent SDK) receive an
 a budget, so an inert budget is never silent.
 
 With LangChain you no longer need the middleware just to make a budget bind.
-Wiring both is still fine — they agree on a per-conversation key, so the same
-usage is counted once — but **share one session between them** if you do. Each
-otherwise builds its own, and a split pair enforces against one while reporting
-`tokens_remaining` from the other:
+Wiring both is still fine — they derive the same per-conversation key from the
+same run, so usage is counted once, not twice — but **share one session between
+them** if you do. Each otherwise builds its own, and a split pair enforces
+against one while reporting `tokens_remaining` from the other:
 
 ```python
 from agentic_data_contracts.core.session import ContractSession
@@ -948,9 +948,12 @@ To enforce it elsewhere, feed the session yourself:
 session.observe_tokens(my_client.cumulative_tokens, scope="my-run-id")
 ```
 
-Note that limits are checked *before* each tool call, so a breach stops the
-next one — an agent that exhausts its budget and then stops calling tools will
-not be interrupted mid-thought.
+Two limits worth knowing. Usage is observed just before the limit check, so a
+budget the current turn has already blown stops *that* call — but an agent that
+exhausts its budget and then stops calling tools is never interrupted, because
+nothing runs to check. And a sub-agent or subgraph inherits its parent's
+`thread_id`, so its own usage is under-counted rather than added; the budget
+binds on the parent's spend.
 
 ## Optional Dependencies
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,10 @@ from deepagents import create_deep_agent
 tools = create_langchain_tools(dc, adapter=adapter)
 
 # Enforcement is auto-applied: session limits and BLOCKED envelopes from the
-# underlying tools surface as ToolMessage(status="error"). Pair with
-# ContractMiddleware (and apply_middleware=False) for graph-level interception.
+# underlying tools surface as ToolMessage(status="error"). Running inside an
+# agent graph, each tool also reads the run's token usage, so a declared
+# token_budget binds here without the middleware. Pair with ContractMiddleware
+# (and apply_middleware=False) for graph-level interception.
 agent = create_deep_agent(tools=tools)
 ```
 
@@ -918,15 +920,16 @@ resources:
 
 `token_budget` is the one limit this library cannot measure on its own — the
 tokens are spent by the *model* between tool calls. It is fed from the host
-framework's own counter, which two paths currently read: the **Pydantic AI**
-adapter (`ctx.usage`) and LangChain's **`ContractMiddleware`** (`request.state`,
-scoped per conversation). The other paths warn at wiring time if your contract
-declares a budget, so an inert budget is not silent — with one deliberate
-exception: `create_langchain_tools(..., apply_middleware=False)` stays quiet,
-because that flag is how you signal you are delegating enforcement to
-`ContractMiddleware`. Wire the middleware if you set it.
+framework's own counter, which the **Pydantic AI** adapter (`ctx.usage`) and
+both **LangChain** paths read — `create_langchain_tools` and
+`ContractMiddleware` alike, each from the run's own message history. The
+remaining paths (`contract_middleware` and the Claude Agent SDK) receive an
+`args` dict and nothing else; they warn at wiring time if your contract declares
+a budget, so an inert budget is never silent.
 
-With LangChain, **share one session between the tools and the middleware** — each
+With LangChain you no longer need the middleware just to make a budget bind.
+Wiring both is still fine — they agree on a per-conversation key, so the same
+usage is counted once — but **share one session between them** if you do. Each
 otherwise builds its own, and a split pair enforces against one while reporting
 `tokens_remaining` from the other:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,7 +240,7 @@ These are simple counters/timers with guard checks before each tool call. No for
 **Token usage is the one counter the session cannot produce itself,** because
 the tokens are spent by the *model* between tool calls, not by anything this
 library runs. It has to be fed from whatever the host framework exposes, and
-two paths currently read it:
+three paths currently read it:
 
 | Path | Feeds `token_budget`? | Source |
 |---|---|---|
@@ -266,11 +266,25 @@ injects. Three things about that are easy to get wrong:
   `await tool.ainvoke({"sql": ...})` is a supported call shape and passes no
   runtime. A required parameter would break every direct caller to catch a
   mis-wiring that degrades to the old behaviour anyway.
-- **Detection is by type hint.** `ToolNode` calls `get_type_hints()` on the
-  coroutine, and since `tools/langchain.py` uses `from __future__ import
-  annotations`, that import must stay at module level to resolve. A test drives
-  a real `create_agent` for exactly this reason — every test that passes
+- **The annotation is what carries it, not the name.** `ToolNode` triggers on
+  a parameter *named* `runtime` **or** annotated `ToolRuntime` — so renaming
+  this parameter would keep working, while dropping its annotation would
+  silently stop injection. Either way it reads the hints via `get_type_hints()`,
+  and since `tools/langchain.py` uses `from __future__ import annotations`, the
+  `ToolRuntime` import must stay at module level to resolve. A test drives a
+  real `create_agent` for exactly this reason — every test that passes
   `runtime` itself would still pass with injection broken.
+
+Two conversations are told apart by `thread_id`, falling back to the id
+LangGraph stamps on the first message. Both under-count on a *collision*: two
+conversations sharing the last-resort constant key, or a **nested run
+inheriting its parent's `thread_id`** (a sub-agent or subgraph, which
+`create_deep_agent` produces), whose shorter history is then dropped whole by
+the monotone guard rather than added. Appending the config's `checkpoint_ns`
+looks like the fix and is not — it is `tools:<task-id>` and changes on every
+tool call, so it would re-accrue the full total each time. Both cases
+under-enforce, which is the safe direction, and both beat the nothing this
+path observed before v0.35.0.
 
 The two paths that remain blind warn at wiring time, for the same reason
 `Validator` warns about unenforceable `forbidden_operations`: a
@@ -291,10 +305,12 @@ on each call multiplies it; assigning it resets the session at each new run.
 Only the per-scope delta accrues. `record_tokens()` remains the delta-based
 entry point for framework-free callers.
 
-**Known window:** `check_limits()` runs *before* a tool call, so a breach is
-caught at the *next* one. An agent that exhausts its budget and stops calling
-tools never trips it — inherent to enforcing from inside tools, and identical to
-how `max_retries` and `cost_limit_usd` already behave. Now that usage is fed,
+**Known window:** the paths that observe usage do so *before* running
+`check_limits()`, so a budget the current turn has already blown stops that
+call rather than the next. What no amount of ordering fixes is an agent that
+exhausts its budget and then stops calling tools: nothing runs, so nothing
+checks. That is inherent to enforcing from inside tools, and identical to how
+`max_retries` and `cost_limit_usd` already behave. Now that usage is fed,
 `remaining()` reports honest `tokens_remaining` in every `run_query` response,
 which lets the model self-regulate; Pydantic AI's `UsageLimits` is what would
 close the window entirely.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,29 +245,41 @@ two paths currently read it:
 | Path | Feeds `token_budget`? | Source |
 |---|---|---|
 | Pydantic AI tools / toolset | Yes | `ctx.usage.total_tokens`, scoped by `ctx.run_id` |
-| LangChain `ContractMiddleware` | Yes | `usage_metadata` summed over `request.state["messages"]`, scoped by `thread_id` |
-| LangChain `create_langchain_tools` | Not yet | Could take a `ToolRuntime` parameter; not wired |
+| LangChain `ContractMiddleware` | Yes | `usage_metadata` summed over `request.state["messages"]`, scoped per conversation |
+| LangChain `create_langchain_tools` | Yes | the same, from an injected `ToolRuntime` |
 | `contract_middleware` | No | its wrapper receives an `args` dict only |
 | Claude Agent SDK | No | the tool callable receives an `args` dict only |
 
-Note "not yet" rather than "cannot" for `create_langchain_tools`: a
-`StructuredTool` coroutine *can* be handed a `ToolRuntime` (and with it the
-message list and `thread_id`), so that row is a wiring gap, not a capability
-limit. Only the last two are genuinely blind. Stating it as a limit — in docs
-or, worse, in a permanent runtime warning — would be the same
-declared-but-false failure this section is about.
+The two LangChain rows share one implementation (`_observe_usage`), keyed on
+`(state, config)` — the shape both callers can produce. That is deliberate:
+fed the same run they derive the same scope key and observe the same cumulative
+total, so wiring both does not double-count, and neither can drift into
+disagreeing about a session's total.
 
-The paths that do not feed it warn at wiring time, for the same reason
+`create_langchain_tools` gets there by declaring a `runtime: ToolRuntime | None`
+parameter on its `StructuredTool` coroutine, which LangGraph's `ToolNode`
+injects. Three things about that are easy to get wrong:
+
+- **It never reaches the model.** `infer_schema=False` means the advertised
+  schema is the tool's JSON Schema dict verbatim, not the coroutine signature.
+- **It is optional on purpose.** Injection only happens inside a graph;
+  `await tool.ainvoke({"sql": ...})` is a supported call shape and passes no
+  runtime. A required parameter would break every direct caller to catch a
+  mis-wiring that degrades to the old behaviour anyway.
+- **Detection is by type hint.** `ToolNode` calls `get_type_hints()` on the
+  coroutine, and since `tools/langchain.py` uses `from __future__ import
+  annotations`, that import must stay at module level to resolve. A test drives
+  a real `create_agent` for exactly this reason — every test that passes
+  `runtime` itself would still pass with injection broken.
+
+The two paths that remain blind warn at wiring time, for the same reason
 `Validator` warns about unenforceable `forbidden_operations`: a
 declared-but-unenforced limit is worse than an absent one, because the contract
-reads as protective while permitting the thing it names. `create_langchain_tools`
-stays quiet when `apply_middleware=False`, since that is exactly how a caller
-signals it is delegating enforcement to `ContractMiddleware` — a warning that
-fires on a correct configuration is how the real ones get ignored.
+reads as protective while permitting the thing it names.
 
-**Both LangChain enforcement pieces must share one `ContractSession`.** They
-each default to constructing their own, and a split pair enforces against the
-middleware's session while `run_query` reports `remaining()` from the tools'
+**Both LangChain enforcement pieces should still share one `ContractSession`.**
+They each default to constructing their own, and a split pair enforces against
+the middleware's session while `run_query` reports `remaining()` from the tools'
 — so the model is told it has its full budget no matter what it spent. Build
 one session and pass it to both.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.34.0"
+version = "0.35.0"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/tools/factory.py
+++ b/src/agentic_data_contracts/tools/factory.py
@@ -83,15 +83,16 @@ def _warn_token_budget_unenforceable(contract: DataContract, path: str) -> None:
     very thing it names.
 
     Note the wording: these paths *do not* observe usage, which is not the same
-    as cannot. Pydantic AI's ``ctx.usage`` and ``ContractMiddleware``'s
-    ``request.state`` are wired; ``create_langchain_tools`` could be, by taking
-    a ``ToolRuntime`` parameter, and is not yet. Only the Claude Agent SDK path
-    is genuinely blind -- its tool callable receives an ``args`` dict and
-    nothing else. Saying "cannot" in a permanent runtime warning would be the
-    same declared-but-false failure in doc form.
+    as cannot. The distinction earned its keep -- ``create_langchain_tools``
+    used to warn from here, and closing that gap was a matter of declaring one
+    ``ToolRuntime`` parameter, not of any new capability. What remains is
+    genuinely blind: ``contract_middleware`` and the Claude Agent SDK path both
+    hand their tool callable an ``args`` dict and nothing else. Still, saying
+    "cannot" in a permanent runtime warning would be the same
+    declared-but-false failure in doc form.
 
     Lives here rather than in each adapter so the message cannot drift between
-    them; ``sdk.py``, ``langchain.py`` and ``middleware.py`` all call it.
+    them; ``sdk.py`` and ``middleware.py`` call it.
     """
     resources = contract.schema.resources
     if resources is None or resources.token_budget is None:

--- a/src/agentic_data_contracts/tools/langchain.py
+++ b/src/agentic_data_contracts/tools/langchain.py
@@ -14,15 +14,15 @@ Two integration paths are offered:
    ``ToolException``. The agent runtime renders those as
    ``ToolMessage(status="error")``.
 
-Both paths observe token usage from the run's message history, so a contract's
-``resources.token_budget`` is enforced either way; the accounting is shared
-(:func:`_observe_usage`) precisely so the two cannot disagree about a session's
-total when a caller wires both.
-
 2. **Graph-level enforcement** — ``ContractMiddleware`` subclasses
    ``langchain.agents.middleware.AgentMiddleware`` and intercepts tool calls
    at the graph boundary. Pair with ``apply_middleware=False`` to avoid
    double work.
+
+Both paths observe token usage from the run's message history, so a contract's
+``resources.token_budget`` is enforced either way; the accounting is shared
+(:func:`_observe_usage`) precisely so the two cannot disagree about a session's
+total when a caller wires both.
 
 Important divergence from ``contract_middleware`` in ``tools.middleware``:
 that decorator validates SQL on *every* tool that has an ``args["sql"]``
@@ -120,11 +120,30 @@ def _usage_scope_for(state: Any, config: Any) -> str:
        checkpointer — which is the shape the README's own LangChain example
        uses.
 
-    Falling back to a bare constant is the *last* resort and is the one case
-    that still under-counts: two conversations sharing it accrue only the
-    larger. It is reached only when there is neither a thread id nor an
-    identified first message, and it under-enforces rather than over-enforces,
-    which is the safe direction to fail.
+    Falling back to a bare constant is the *last* resort, reached only when
+    there is neither a thread id nor an identified first message.
+
+    Two known under-counts, both of them collisions -- distinct runs landing on
+    one key, where ``observe_tokens``' monotone guard then keeps only the
+    larger:
+
+    1. That bare constant, when two conversations share it.
+    2. A **nested run inheriting its parent's thread id** -- a sub-agent or
+       subgraph, which ``create_deep_agent`` produces. Its own history is
+       shorter than the parent's, so its usage is dropped whole rather than
+       merely mixed: a 5000-token parent turn followed by an 800-token
+       sub-agent turn accrues 5000, not 5800.
+
+    The tempting fix for (2) -- appending the config's ``checkpoint_ns`` to
+    separate nested runs -- is wrong, and measurably so: that value is
+    ``tools:<task-id>`` and carries a *fresh* id on every tool call, so it
+    would mint a new scope each time and re-accrue the whole cumulative total,
+    multiplying rather than separating. Fixing this needs a key that is stable
+    within a run and distinct across nesting; there is no such field to hand.
+
+    Both cases under-enforce rather than over-enforce, which is the safe
+    direction to fail, and both are strictly better than the nothing this path
+    observed before v0.35.0.
 
     Deriving the key from ``(state, config)`` rather than from a caller-specific
     object is what lets the middleware and the ``StructuredTool`` path agree:
@@ -240,10 +259,13 @@ def _to_structured_tool(
     plain text on ``ToolMessage.content``.
 
     The ``runtime`` parameter is how a declared ``token_budget`` reaches this
-    path: LangGraph's ``ToolNode`` injects a ``ToolRuntime`` into any tool
-    parameter of that name, carrying the run's message history and thread id.
-    It never reaches the model — ``infer_schema=False`` means the advertised
-    schema is ``tool_def.input_schema`` verbatim, not this signature.
+    path: LangGraph's ``ToolNode`` injects a ``ToolRuntime`` carrying the run's
+    message history and thread id. It triggers on the parameter being *named*
+    ``runtime`` **or** annotated ``ToolRuntime`` — either alone suffices, so
+    renaming this parameter would keep working while dropping the annotation
+    would not. The annotation is therefore the load-bearing half. It never
+    reaches the model — ``infer_schema=False`` means the advertised schema is
+    ``tool_def.input_schema`` verbatim, not this signature.
 
     It is optional, and defaults to ``None``, because injection only happens
     inside a graph: ``await tool.ainvoke({"sql": ...})`` is a supported way to
@@ -262,8 +284,16 @@ def _to_structured_tool(
         # ContractMiddleware, and observation is not enforcement. Both feeding
         # one session is harmless -- they derive the same scope key from the
         # same run, so the second observation of a total is a no-op.
+        # Read defensively, matching ContractMiddleware._state_and_config: a
+        # non-LangGraph harness that forwards raw tool-call args could put
+        # anything under this key, and an AttributeError from accounting must
+        # not be how a governed query fails.
         if runtime is not None:
-            _observe_usage(session, runtime.state, runtime.config)
+            _observe_usage(
+                session,
+                getattr(runtime, "state", None),
+                getattr(runtime, "config", None),
+            )
 
         if apply_middleware:
             try:
@@ -353,10 +383,6 @@ class ContractMiddleware(AgentMiddleware):
         the two drift into disagreeing about one session's total.
         """
         _observe_usage(self._session, *self._state_and_config(request))
-
-    def _usage_scope(self, request: ToolCallRequest) -> str:
-        """Conversation key for this request. See :func:`_usage_scope_for`."""
-        return _usage_scope_for(*self._state_and_config(request))
 
     def _check(self, request: ToolCallRequest) -> ToolMessage | None:
         """Run enforcement against a request. Returns a short-circuit

--- a/src/agentic_data_contracts/tools/langchain.py
+++ b/src/agentic_data_contracts/tools/langchain.py
@@ -14,6 +14,11 @@ Two integration paths are offered:
    ``ToolException``. The agent runtime renders those as
    ``ToolMessage(status="error")``.
 
+Both paths observe token usage from the run's message history, so a contract's
+``resources.token_budget`` is enforced either way; the accounting is shared
+(:func:`_observe_usage`) precisely so the two cannot disagree about a session's
+total when a caller wires both.
+
 2. **Graph-level enforcement** — ``ContractMiddleware`` subclasses
    ``langchain.agents.middleware.AgentMiddleware`` and intercepts tool calls
    at the graph boundary. Pair with ``apply_middleware=False`` to avoid
@@ -38,6 +43,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from langchain.agents.middleware.types import AgentMiddleware, ToolCallRequest
+
+# Imported at module level, not inside the coroutine, because that is what makes
+# the injection work: LangGraph's ToolNode decides whether to hand a tool its
+# ToolRuntime by calling `get_type_hints()` on the coroutine, and this module
+# uses `from __future__ import annotations`, so the hint is the *string*
+# "ToolRuntime | None" and must resolve against these module globals.
+from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import BaseTool, StructuredTool, ToolException
 from langgraph.types import Command
@@ -49,7 +61,6 @@ from agentic_data_contracts.semantic.base import SemanticSource
 from agentic_data_contracts.tools.factory import (
     RowFormat,
     ToolDef,
-    _warn_token_budget_unenforceable,
     create_tools,
 )
 from agentic_data_contracts.validation.validator import Validator
@@ -79,6 +90,91 @@ def _unwrap_mcp_text(envelope: dict[str, Any]) -> str:
         return ""
     except (AttributeError, TypeError):
         return ""
+
+
+def _messages_in(state: Any) -> list[Any]:
+    """Pull the message list out of a graph state, tolerating its absence.
+
+    Both callers receive state from the framework rather than constructing it,
+    and both can legitimately be handed nothing: a middleware invoked outside a
+    graph, or a tool invoked directly with no ``ToolRuntime`` to inject.
+    """
+    if not state:
+        return []
+    try:
+        return list(state["messages"] or [])
+    except (KeyError, TypeError):
+        return []
+
+
+def _usage_scope_for(state: Any, config: Any) -> str:
+    """Identify the conversation whose running total is being observed.
+
+    Two sources, tried in order, because neither covers every wiring:
+
+    1. ``thread_id`` from the runtime config — present whenever a checkpointer
+       is configured, and stable across turns.
+    2. The id of the first message in state. LangGraph's ``add_messages``
+       reducer assigns a UUID as messages enter state, and the first one stays
+       put across turns, so it identifies a conversation even with no
+       checkpointer — which is the shape the README's own LangChain example
+       uses.
+
+    Falling back to a bare constant is the *last* resort and is the one case
+    that still under-counts: two conversations sharing it accrue only the
+    larger. It is reached only when there is neither a thread id nor an
+    identified first message, and it under-enforces rather than over-enforces,
+    which is the safe direction to fail.
+
+    Deriving the key from ``(state, config)`` rather than from a caller-specific
+    object is what lets the middleware and the ``StructuredTool`` path agree:
+    fed the same run, they compute the same key, so a session wired to both
+    observes one cumulative total instead of two competing ones.
+    """
+    thread_id = ((config or {}).get("configurable") or {}).get("thread_id")
+    if thread_id:
+        return f"langchain:thread:{thread_id}"
+
+    messages = _messages_in(state)
+    if messages:
+        first_id = getattr(messages[0], "id", None)
+        if first_id:
+            return f"langchain:conv:{first_id}"
+
+    return "langchain"
+
+
+def _observe_usage(session: ContractSession, state: Any, config: Any) -> None:
+    """Feed the contract's ``token_budget`` from a run's message history.
+
+    ``usage_metadata`` is **per message**, so the running total is the *sum*
+    over the list -- do not "simplify" this to the last message's total, which
+    would undercount by an order of magnitude. The sum grows monotonically as
+    messages append, which is what ``ContractSession.observe_tokens`` expects.
+
+    Scoped per conversation, never by a constant: one middleware instance (and
+    one tool list) serves every conversation an agent handles, and a shared key
+    silently drops the second conversation's usage whenever its running sum sits
+    below the first's peak -- under-enforcing *and* reporting a false
+    ``tokens_remaining`` to the model, which is the failure this feature exists
+    to remove. See :func:`_usage_scope_for`.
+
+    Two accepted limits. Concurrent conversations still share one
+    ``ContractSession``, so the budget is a combined ceiling across them rather
+    than per-conversation -- correct for a per-user session, worth knowing if
+    you share one more widely. And a middleware that trims or summarises history
+    (``SummarizationMiddleware``, ``trim_messages``) shrinks the sum; the
+    monotone guard refuses to subtract, so accrual pauses until the new sum
+    passes the old peak. That under-enforces rather than over-enforces, which is
+    the safe direction.
+    """
+    total = 0
+    for message in _messages_in(state):
+        usage = getattr(message, "usage_metadata", None)
+        if isinstance(usage, dict):
+            total += int(usage.get("total_tokens") or 0)
+    if total:
+        session.observe_tokens(total, scope=_usage_scope_for(state, config))
 
 
 def create_langchain_tools(
@@ -117,16 +213,6 @@ def create_langchain_tools(
         A list of ``BaseTool`` instances; order matches the underlying
         ``create_tools()`` output.
     """
-    # This path's StructuredTool coroutines are not wired for run state, so a
-    # declared token_budget is inert here -- say so rather than fail silently.
-    # But `apply_middleware=False` is exactly how a caller signals it is
-    # delegating enforcement to ContractMiddleware, which *does* observe usage,
-    # so warning then would cry wolf in the configuration the README teaches --
-    # and a warning that fires when things are correct is how the real ones get
-    # ignored.
-    if apply_middleware:
-        _warn_token_budget_unenforceable(contract, "create_langchain_tools")
-
     if session is None:
         session = ContractSession(contract)
 
@@ -152,10 +238,33 @@ def _to_structured_tool(
     The coroutine returns ``(content_str, raw_envelope)`` so the original
     MCP dict survives on ``ToolMessage.artifact`` while the model sees
     plain text on ``ToolMessage.content``.
+
+    The ``runtime`` parameter is how a declared ``token_budget`` reaches this
+    path: LangGraph's ``ToolNode`` injects a ``ToolRuntime`` into any tool
+    parameter of that name, carrying the run's message history and thread id.
+    It never reaches the model — ``infer_schema=False`` means the advertised
+    schema is ``tool_def.input_schema`` verbatim, not this signature.
+
+    It is optional, and defaults to ``None``, because injection only happens
+    inside a graph: ``await tool.ainvoke({"sql": ...})`` is a supported way to
+    call these tools and passes no runtime at all. A required parameter would
+    break every such caller to catch a mis-wiring that degrades to the previous
+    behaviour anyway — usage simply goes unobserved, exactly as it did before.
     """
     inner = tool_def.callable
 
-    async def _coroutine(**kwargs: Any) -> tuple[str, dict[str, Any]]:
+    async def _coroutine(
+        runtime: ToolRuntime | None = None, **kwargs: Any
+    ) -> tuple[str, dict[str, Any]]:
+        # Observe before checking, so a breach that this very run caused blocks
+        # now rather than one tool call later. Unconditional, unlike the limit
+        # check below: `apply_middleware=False` delegates *enforcement* to
+        # ContractMiddleware, and observation is not enforcement. Both feeding
+        # one session is harmless -- they derive the same scope key from the
+        # same run, so the second observation of a total is a no-op.
+        if runtime is not None:
+            _observe_usage(session, runtime.state, runtime.config)
+
         if apply_middleware:
             try:
                 session.check_limits()
@@ -224,88 +333,30 @@ class ContractMiddleware(AgentMiddleware):
             sql_normalizer=sql_normalizer,
         )
 
+    @staticmethod
+    def _state_and_config(request: ToolCallRequest) -> tuple[Any, Any]:
+        """Unpack the two things usage accounting needs from a request.
+
+        ``runtime`` is typed non-optional on ``ToolCallRequest`` but read
+        defensively: a hand-built request, or one from outside a graph, has
+        neither a runtime nor a config.
+        """
+        runtime = getattr(request, "runtime", None)
+        return getattr(request, "state", None), getattr(runtime, "config", None)
+
     def _observe_token_usage(self, request: ToolCallRequest) -> None:
         """Feed the contract's ``token_budget`` from the run's message history.
 
-        This middleware is the only LangChain path that currently reads run
-        state; ``create_langchain_tools``' ``StructuredTool`` coroutines are not
-        wired for it, so a contract's token budget is inert there (the factory
-        warns about it).
-
-        ``usage_metadata`` is **per message**, so the running total is the
-        *sum* over the list -- do not "simplify" this to the last message's
-        total, which would undercount by an order of magnitude. The sum grows
-        monotonically as messages append, which is what
-        ``ContractSession.observe_tokens`` expects.
-
-        Scoped per conversation, never by a constant: one middleware instance
-        serves every conversation an agent handles (the README wires exactly
-        one), and a shared key silently drops the second conversation's usage
-        whenever its running sum sits below the first's peak -- under-enforcing
-        *and* reporting a false ``tokens_remaining`` to the model, which is the
-        failure this feature exists to remove. See :meth:`_usage_scope`.
-
-        Two accepted limits. Concurrent conversations still share one
-        ``ContractSession``, so the budget is a combined ceiling across them
-        rather than per-conversation -- correct for a per-user session, worth
-        knowing if you share one more widely. And a middleware that trims or
-        summarises history (``SummarizationMiddleware``, ``trim_messages``)
-        shrinks the sum; the monotone guard refuses to subtract, so accrual
-        pauses until the new sum passes the old peak. That under-enforces
-        rather than over-enforces, which is the safe direction.
+        The accounting lives in :func:`_observe_usage`, shared with the
+        ``StructuredTool`` path in :func:`_to_structured_tool` — both observe
+        the same run, and copying the summing or the scope derivation would let
+        the two drift into disagreeing about one session's total.
         """
-        state = getattr(request, "state", None)
-        if not state:
-            return
-        try:
-            messages = state["messages"]
-        except (KeyError, TypeError):
-            return
-        total = 0
-        for message in messages or []:
-            usage = getattr(message, "usage_metadata", None)
-            if isinstance(usage, dict):
-                total += int(usage.get("total_tokens") or 0)
-        if total:
-            self._session.observe_tokens(total, scope=self._usage_scope(request))
+        _observe_usage(self._session, *self._state_and_config(request))
 
-    @staticmethod
-    def _usage_scope(request: ToolCallRequest) -> str:
-        """Identify the conversation whose running total is being observed.
-
-        Two sources, tried in order, because neither covers every wiring:
-
-        1. ``thread_id`` from the runtime config — present whenever a
-           checkpointer is configured, and stable across turns.
-        2. The id of the first message in state. LangGraph's ``add_messages``
-           reducer assigns a UUID as messages enter state, and the first one
-           stays put across turns, so it identifies a conversation even with no
-           checkpointer — which is the shape the README's own LangChain example
-           uses.
-
-        Falling back to a bare constant is the *last* resort and is the one
-        case that still under-counts: two conversations sharing it accrue only
-        the larger. It is reached only when there is neither a thread id nor an
-        identified first message, and it under-enforces rather than
-        over-enforces, which is the safe direction to fail.
-        """
-        runtime = getattr(request, "runtime", None)
-        config = getattr(runtime, "config", None) or {}
-        thread_id = (config.get("configurable") or {}).get("thread_id")
-        if thread_id:
-            return f"langchain:thread:{thread_id}"
-
-        state = getattr(request, "state", None)
-        try:
-            messages = state["messages"] if state else None
-        except (KeyError, TypeError):
-            messages = None
-        if messages:
-            first_id = getattr(messages[0], "id", None)
-            if first_id:
-                return f"langchain:conv:{first_id}"
-
-        return "langchain"
+    def _usage_scope(self, request: ToolCallRequest) -> str:
+        """Conversation key for this request. See :func:`_usage_scope_for`."""
+        return _usage_scope_for(*self._state_and_config(request))
 
     def _check(self, request: ToolCallRequest) -> ToolMessage | None:
         """Run enforcement against a request. Returns a short-circuit

--- a/tests/test_tools/test_langchain.py
+++ b/tests/test_tools/test_langchain.py
@@ -14,6 +14,7 @@ pytest.importorskip("langchain_core")
 pytest.importorskip("langchain")
 
 from langchain.agents.middleware.types import ToolCallRequest  # noqa: E402
+from langchain.tools import ToolRuntime  # noqa: E402
 from langchain_core.tools import BaseTool, ToolException  # noqa: E402
 
 from agentic_data_contracts.adapters.duckdb import DuckDBAdapter  # noqa: E402
@@ -482,42 +483,21 @@ def _budgeted_contract() -> DataContract:
     )
 
 
-def test_structured_tool_path_warns_that_budget_is_inert(
-    caplog: pytest.LogCaptureFixture, adapter: DuckDBAdapter
+@pytest.mark.parametrize("apply_middleware", [True, False])
+def test_no_wiring_time_warning_now_that_this_path_observes_usage(
+    caplog: pytest.LogCaptureFixture, adapter: DuckDBAdapter, apply_middleware: bool
 ) -> None:
-    # A declared-but-unenforced limit is worse than an absent one: the contract
-    # reads as protective while permitting the thing it names. This path does
-    # not read run state, so it must say so.
-    with caplog.at_level(logging.WARNING):
-        create_langchain_tools(_budgeted_contract(), adapter=adapter)
-    assert "token_budget" in caplog.text
-    assert "NOT be enforced" in caplog.text
-    assert "ContractMiddleware" in caplog.text
+    """v0.35.0 removed the warning by removing what it warned about.
 
-
-def test_no_warning_when_delegating_to_the_middleware(
-    caplog: pytest.LogCaptureFixture, adapter: DuckDBAdapter
-) -> None:
-    """`apply_middleware=False` is how a caller signals delegation.
-
-    Warning then would fire on the configuration the README teaches, and a
-    warning that cries wolf on a correct setup is how the real ones get
-    filtered out.
+    Both flag values are checked because the warning used to be gated on this
+    flag -- `apply_middleware=False` meant "delegating to ContractMiddleware,
+    do not cry wolf". With the tools themselves observing usage, neither value
+    leaves a budget inert, so the gate went with the warning.
     """
     with caplog.at_level(logging.WARNING):
         create_langchain_tools(
-            _budgeted_contract(), adapter=adapter, apply_middleware=False
+            _budgeted_contract(), adapter=adapter, apply_middleware=apply_middleware
         )
-    assert "token_budget" not in caplog.text
-
-
-def test_no_warning_when_no_budget_declared(
-    caplog: pytest.LogCaptureFixture, adapter: DuckDBAdapter
-) -> None:
-    unbudgeted = _budgeted_contract()
-    unbudgeted.schema.resources = None
-    with caplog.at_level(logging.WARNING):
-        create_langchain_tools(unbudgeted, adapter=adapter)
     assert "token_budget" not in caplog.text
 
 
@@ -637,3 +617,232 @@ def test_middleware_blocks_once_the_budget_is_spent() -> None:
     blocked = middleware._check(_usage_request(50_001, thread_id="A"))
     assert blocked is not None
     assert "token budget exceeded" in str(blocked.content)
+
+
+# ─── token budget on the StructuredTool path (v0.35.0) ────────────────────────
+
+
+def _tool_runtime(
+    total: int, thread_id: str | None = None, message_id: str | None = None
+) -> Any:
+    """A real ToolRuntime carrying one usage-bearing AIMessage.
+
+    The same run, described from the tool's side rather than the middleware's:
+    ``ToolNode`` builds one of these per tool call and injects it into any
+    parameter named ``runtime``.
+    """
+    from langchain_core.messages import AIMessage
+
+    return ToolRuntime(
+        state=cast(
+            Any,
+            {
+                "messages": [
+                    AIMessage(
+                        id=message_id,
+                        content="x",
+                        usage_metadata={
+                            "input_tokens": total - 300,
+                            "output_tokens": 300,
+                            "total_tokens": total,
+                        },
+                    )
+                ]
+            },
+        ),
+        context=None,
+        config=cast(
+            Any, {"configurable": {"thread_id": thread_id}} if thread_id else {}
+        ),
+        stream_writer=cast(Any, lambda _: None),
+        tool_call_id="call-1",
+        store=None,
+    )
+
+
+def _budgeted_query_tool(
+    session: ContractSession, adapter: DuckDBAdapter, **kwargs: Any
+) -> BaseTool:
+    tools = create_langchain_tools(
+        _budgeted_contract(), adapter=adapter, session=session, **kwargs
+    )
+    return next(t for t in tools if t.name == "run_query")
+
+
+_QUERY = {"sql": "SELECT * FROM analytics.orders"}
+
+
+async def test_structured_tool_feeds_the_budget_from_run_state(
+    adapter: DuckDBAdapter,
+) -> None:
+    """The gap this release closes: no middleware, budget still enforced."""
+    session = ContractSession(_budgeted_contract())
+    tool = _budgeted_query_tool(session, adapter)
+
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1200, thread_id="T1")})
+    assert session.tokens_used == 1200
+    # Cumulative, not additive: re-observing the same history must not
+    # double-count it.
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1200, thread_id="T1")})
+    assert session.tokens_used == 1200
+
+
+async def test_structured_tool_keeps_two_conversations_apart(
+    adapter: DuckDBAdapter,
+) -> None:
+    """One tool list serves every conversation, exactly as one middleware does.
+
+    A constant scope key drops thread B entirely -- 1000 is not greater than
+    A's 1000 -- and then reports B its full budget. That defect was caught on
+    the middleware during the v0.34.0 review; sharing the scope derivation is
+    what stops it being reintroduced here.
+    """
+    session = ContractSession(_budgeted_contract())
+    tool = _budgeted_query_tool(session, adapter)
+
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1000, thread_id="A")})
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1000, thread_id="B")})
+    assert session.tokens_used == 2000
+
+
+async def test_structured_tool_separates_unthreaded_conversations(
+    adapter: DuckDBAdapter,
+) -> None:
+    # No checkpointer is the README's own LangChain wiring; the first message's
+    # reducer-assigned UUID is what distinguishes conversations there.
+    session = ContractSession(_budgeted_contract())
+    tool = _budgeted_query_tool(session, adapter)
+
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1000, message_id="conv-a")})
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1000, message_id="conv-b")})
+    assert session.tokens_used == 2000
+
+
+async def test_structured_tool_blocks_once_the_budget_is_spent(
+    adapter: DuckDBAdapter,
+) -> None:
+    """Observation precedes the limit check, so the breaching run stops itself.
+
+    Checking first would let the offending call through and block the *next*
+    one -- and if the agent stops calling tools after it, never block at all.
+    """
+    session = ContractSession(_budgeted_contract())
+    tool = _budgeted_query_tool(session, adapter)
+
+    with pytest.raises(ToolException) as excinfo:
+        await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(50_001, thread_id="A")})
+    assert "token budget exceeded" in str(excinfo.value)
+
+
+async def test_tools_and_middleware_on_one_session_do_not_double_count(
+    adapter: DuckDBAdapter,
+) -> None:
+    """Wiring both is legal, so it must not halve the effective budget.
+
+    Fed the same run, the two paths derive the same scope key and observe the
+    same cumulative total, so whichever runs second is a no-op. This is the
+    property that makes the tool-path observation safe to leave unconditional
+    rather than gating it on ``apply_middleware``.
+    """
+    session = ContractSession(_budgeted_contract())
+    middleware = ContractMiddleware(_budgeted_contract(), session=session)
+    tool = _budgeted_query_tool(session, adapter, apply_middleware=False)
+
+    middleware._observe_token_usage(_usage_request(1200, thread_id="T1"))
+    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1200, thread_id="T1")})
+    assert session.tokens_used == 1200
+
+
+async def test_direct_invocation_without_a_runtime_still_works(
+    adapter: DuckDBAdapter,
+) -> None:
+    """``runtime`` is injected by ToolNode, not by ``ainvoke``.
+
+    Calling a tool directly is a supported shape -- most of this file does it --
+    so the parameter has to be optional. Nothing is observed, which is exactly
+    the pre-v0.35.0 behaviour rather than a new failure.
+    """
+    session = ContractSession(_budgeted_contract())
+    tool = _budgeted_query_tool(session, adapter)
+
+    result = await tool.ainvoke(_QUERY)
+    assert "acme" in str(result)
+    assert session.tokens_used == 0
+
+
+async def test_budget_is_fed_through_a_real_agent(adapter: DuckDBAdapter) -> None:
+    """The load-bearing test: does ToolNode actually inject the runtime?
+
+    Every other test in this section hands ``runtime`` over itself, so all of
+    them would still pass if injection never happened -- and injection is the
+    entire feature. It hinges on something invisible at the call site:
+    ``ToolNode`` runs ``get_type_hints()`` over the coroutine to decide whether
+    to inject, and because ``tools/langchain.py`` uses ``from __future__ import
+    annotations`` that resolution needs ``ToolRuntime`` in the module's globals.
+
+    Verified by mutation: moving that import into function scope fails this
+    test and no other. It fails loudly there (``NameError`` from the hint
+    evaluation), but renaming the parameter or dropping its annotation would
+    stop injection in silence, and only a real graph run notices either.
+    """
+    from langchain.agents import create_agent
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import AIMessage
+
+    class _ToolCallingModel(GenericFakeChatModel):
+        # The fake model does not implement tool binding; create_agent only
+        # needs the bound object back, and the replies are scripted anyway.
+        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
+            return self
+
+    replies = iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "run_query",
+                        "args": _QUERY,
+                        "id": "c1",
+                        "type": "tool_call",
+                    }
+                ],
+                usage_metadata={
+                    "input_tokens": 700,
+                    "output_tokens": 300,
+                    "total_tokens": 1000,
+                },
+            ),
+            AIMessage(content="1 row."),
+        ]
+    )
+
+    session = ContractSession(_budgeted_contract())
+    agent = create_agent(
+        model=_ToolCallingModel(messages=replies),
+        tools=create_langchain_tools(
+            _budgeted_contract(), adapter=adapter, session=session
+        ),
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [("user", "count the orders")]},
+        config={"configurable": {"thread_id": "T1"}},
+    )
+
+    # The tool ran, and the assistant turn that requested it was billed to the
+    # session -- which before this release stayed at zero forever.
+    assert any(m.type == "tool" for m in result["messages"])
+    assert session.tokens_used == 1000
+
+
+def test_runtime_is_never_advertised_to_the_model(adapter: DuckDBAdapter) -> None:
+    """``infer_schema=False`` means the dict schema is the schema.
+
+    If the coroutine signature ever started driving the advertised arguments,
+    the model would see a ``runtime`` parameter it cannot fill and would try.
+    """
+    session = ContractSession(_budgeted_contract())
+    tool = _budgeted_query_tool(session, adapter)
+    assert "runtime" not in tool.args
+    assert set(tool.args) == {"sql"}

--- a/tests/test_tools/test_langchain.py
+++ b/tests/test_tools/test_langchain.py
@@ -30,7 +30,9 @@ from agentic_data_contracts.semantic.yaml_source import YamlSource  # noqa: E402
 from agentic_data_contracts.tools.factory import create_tools  # noqa: E402
 from agentic_data_contracts.tools.langchain import (  # noqa: E402
     ContractMiddleware,
+    _observe_usage,
     _unwrap_mcp_text,
+    _usage_scope_for,
     create_langchain_tools,
 )
 
@@ -545,8 +547,9 @@ def _usage_request(
 
 
 def test_middleware_feeds_the_budget_from_run_state() -> None:
-    # The middleware is the one LangChain path that reads run state, so it is
-    # the one that can make a declared token_budget real.
+    # Reading run state is what makes a declared token_budget real. As of
+    # v0.35.0 the StructuredTool path does it too, from the same helpers --
+    # see the tool-path section below.
     session = ContractSession(_budgeted_contract())
     middleware = ContractMiddleware(_budgeted_contract(), session=session)
 
@@ -603,10 +606,37 @@ def test_unthreaded_conversations_separate_by_message_id() -> None:
 def test_thread_id_wins_over_message_id() -> None:
     # A configured checkpointer is the stronger signal: it survives history
     # trimming that could drop the first message entirely.
-    session = ContractSession(_budgeted_contract())
-    middleware = ContractMiddleware(_budgeted_contract(), session=session)
-    scope = middleware._usage_scope(_usage_request(10, thread_id="T", message_id="M"))
+    request = _usage_request(10, thread_id="T", message_id="M")
+    scope = _usage_scope_for(*ContractMiddleware._state_and_config(request))
     assert scope == "langchain:thread:T"
+
+
+def test_nested_run_sharing_a_thread_id_under_counts() -> None:
+    """A documented limitation, pinned so it cannot change unnoticed.
+
+    A sub-agent or subgraph inherits its parent's ``thread_id`` but carries a
+    shorter history of its own, so it collides on the scope key and the
+    monotone guard drops its usage whole rather than mixing it: 5000 + 800
+    accrues 5000. The obvious key extension does not work -- the config's
+    ``checkpoint_ns`` is ``tools:<task-id>`` and changes on *every* tool call,
+    so keying on it would re-accrue the full total each time, multiplying
+    instead of separating.
+
+    Asserted rather than merely commented because the failure is silent and in
+    the safe direction, which is exactly the kind that survives for releases.
+    """
+    session = ContractSession(_budgeted_contract())
+    state, config = ContractMiddleware._state_and_config(
+        _usage_request(5000, thread_id="T1")
+    )
+    _observe_usage(session, state, config)
+
+    nested_state, nested_config = ContractMiddleware._state_and_config(
+        _usage_request(800, thread_id="T1")
+    )
+    _observe_usage(session, nested_state, nested_config)
+
+    assert session.tokens_used == 5000  # true spend is 5800
 
 
 def test_middleware_blocks_once_the_budget_is_spent() -> None:
@@ -734,25 +764,6 @@ async def test_structured_tool_blocks_once_the_budget_is_spent(
     assert "token budget exceeded" in str(excinfo.value)
 
 
-async def test_tools_and_middleware_on_one_session_do_not_double_count(
-    adapter: DuckDBAdapter,
-) -> None:
-    """Wiring both is legal, so it must not halve the effective budget.
-
-    Fed the same run, the two paths derive the same scope key and observe the
-    same cumulative total, so whichever runs second is a no-op. This is the
-    property that makes the tool-path observation safe to leave unconditional
-    rather than gating it on ``apply_middleware``.
-    """
-    session = ContractSession(_budgeted_contract())
-    middleware = ContractMiddleware(_budgeted_contract(), session=session)
-    tool = _budgeted_query_tool(session, adapter, apply_middleware=False)
-
-    middleware._observe_token_usage(_usage_request(1200, thread_id="T1"))
-    await tool.ainvoke({**_QUERY, "runtime": _tool_runtime(1200, thread_id="T1")})
-    assert session.tokens_used == 1200
-
-
 async def test_direct_invocation_without_a_runtime_still_works(
     adapter: DuckDBAdapter,
 ) -> None:
@@ -770,29 +781,21 @@ async def test_direct_invocation_without_a_runtime_still_works(
     assert session.tokens_used == 0
 
 
-async def test_budget_is_fed_through_a_real_agent(adapter: DuckDBAdapter) -> None:
-    """The load-bearing test: does ToolNode actually inject the runtime?
+def _scripted_agent(tools: list[BaseTool], turn_tokens: int, **kwargs: Any) -> Any:
+    """A real ``create_agent`` whose model is scripted to call ``run_query`` once.
 
-    Every other test in this section hands ``runtime`` over itself, so all of
-    them would still pass if injection never happened -- and injection is the
-    entire feature. It hinges on something invisible at the call site:
-    ``ToolNode`` runs ``get_type_hints()`` over the coroutine to decide whether
-    to inject, and because ``tools/langchain.py`` uses ``from __future__ import
-    annotations`` that resolution needs ``ToolRuntime`` in the module's globals.
-
-    Verified by mutation: moving that import into function scope fails this
-    test and no other. It fails loudly there (``NameError`` from the hint
-    evaluation), but renaming the parameter or dropping its annotation would
-    stop injection in silence, and only a real graph run notices either.
+    Real graph, real ``ToolNode``, real injection — only the model is faked,
+    and only so the tool call and its ``usage_metadata`` are deterministic.
+    ``bind_tools`` is overridden because the fake does not implement it;
+    ``create_agent`` only needs the bound object back, and binding happens
+    upstream of injection either way.
     """
     from langchain.agents import create_agent
     from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
     from langchain_core.messages import AIMessage
 
     class _ToolCallingModel(GenericFakeChatModel):
-        # The fake model does not implement tool binding; create_agent only
-        # needs the bound object back, and the replies are scripted anyway.
-        def bind_tools(self, tools: Any, **kwargs: Any) -> Any:
+        def bind_tools(self, tools: Any, **kw: Any) -> Any:
             return self
 
     replies = iter(
@@ -808,21 +811,41 @@ async def test_budget_is_fed_through_a_real_agent(adapter: DuckDBAdapter) -> Non
                     }
                 ],
                 usage_metadata={
-                    "input_tokens": 700,
+                    "input_tokens": turn_tokens - 300,
                     "output_tokens": 300,
-                    "total_tokens": 1000,
+                    "total_tokens": turn_tokens,
                 },
             ),
             AIMessage(content="1 row."),
         ]
     )
+    return create_agent(
+        model=_ToolCallingModel(messages=replies), tools=tools, **kwargs
+    )
 
+
+async def test_budget_is_fed_through_a_real_agent(adapter: DuckDBAdapter) -> None:
+    """The load-bearing test: does ToolNode actually inject the runtime?
+
+    Every other test in this section hands ``runtime`` over itself, so all of
+    them would still pass if injection never happened -- and injection is the
+    entire feature. It hinges on something invisible at the call site:
+    ``ToolNode`` runs ``get_type_hints()`` over the coroutine to decide whether
+    to inject, and because ``tools/langchain.py`` uses ``from __future__ import
+    annotations`` that resolution needs ``ToolRuntime`` in the module's globals.
+
+    Verified by mutation, twice. Moving that import into function scope fails
+    this test and no other (loudly -- ``NameError`` out of the hint
+    evaluation). Dropping the parameter's annotation also fails this test and
+    no other, and *that* one is silent. Renaming the parameter, contrary to
+    what one might assume, does not break injection at all: ToolNode triggers
+    on the name ``runtime`` **or** the ``ToolRuntime`` annotation, so the
+    annotation is the half that carries the feature.
+    """
     session = ContractSession(_budgeted_contract())
-    agent = create_agent(
-        model=_ToolCallingModel(messages=replies),
-        tools=create_langchain_tools(
-            _budgeted_contract(), adapter=adapter, session=session
-        ),
+    agent = _scripted_agent(
+        create_langchain_tools(_budgeted_contract(), adapter=adapter, session=session),
+        turn_tokens=1000,
     )
 
     result = await agent.ainvoke(
@@ -833,6 +856,67 @@ async def test_budget_is_fed_through_a_real_agent(adapter: DuckDBAdapter) -> Non
     # The tool ran, and the assistant turn that requested it was billed to the
     # session -- which before this release stayed at zero forever.
     assert any(m.type == "tool" for m in result["messages"])
+    assert session.tokens_used == 1000
+
+
+async def test_tools_and_middleware_on_one_session_do_not_double_count(
+    adapter: DuckDBAdapter,
+) -> None:
+    """Wiring both is legal, so it must not halve the effective budget.
+
+    Driven through a real graph on purpose. Asserting this against two
+    hand-built inputs would only prove ``observe_tokens`` is idempotent for an
+    equal ``(scope, total)`` pair, which was never in doubt -- the claim worth
+    guarding is that the two paths *derive* the same scope and the same total
+    from one run, having reached it by different routes (``request.state`` and
+    ``request.runtime.config`` versus ``ToolRuntime.state`` and
+    ``.config``). That derivation agreeing is what makes the tool-path
+    observation safe to leave unconditional instead of gating it on
+    ``apply_middleware``, which governs enforcement rather than observation.
+    """
+    session = ContractSession(_budgeted_contract())
+    agent = _scripted_agent(
+        create_langchain_tools(
+            _budgeted_contract(),
+            adapter=adapter,
+            session=session,
+            apply_middleware=False,
+        ),
+        turn_tokens=1000,
+        middleware=[ContractMiddleware(_budgeted_contract(), session=session)],
+    )
+
+    await agent.ainvoke(
+        {"messages": [("user", "count the orders")]},
+        config={"configurable": {"thread_id": "T1"}},
+    )
+
+    # Both observed; counted once. 2000 here would mean the scope keys or the
+    # totals diverged between the two paths.
+    assert session.tokens_used == 1000
+
+
+async def test_both_paths_agree_without_a_checkpointer(adapter: DuckDBAdapter) -> None:
+    """The same agreement, on the ``conv:`` branch of the scope key.
+
+    Without a ``thread_id`` the key falls back to the id LangGraph stamps on
+    the first message -- a different branch of ``_usage_scope_for``, and the
+    README's own LangChain wiring. Both paths must land on the same id.
+    """
+    session = ContractSession(_budgeted_contract())
+    agent = _scripted_agent(
+        create_langchain_tools(
+            _budgeted_contract(),
+            adapter=adapter,
+            session=session,
+            apply_middleware=False,
+        ),
+        turn_tokens=1000,
+        middleware=[ContractMiddleware(_budgeted_contract(), session=session)],
+    )
+
+    await agent.ainvoke({"messages": [("user", "count the orders")]})
+
     assert session.tokens_used == 1000
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #52.

v0.34.0 gave `resources.token_budget` a producer on two of four paths. This closes the third — and removes the wiring-time warning that existed only to describe the gap.

## What changed

The `StructuredTool` coroutine in `create_langchain_tools` now declares a `runtime: ToolRuntime | None` parameter, which LangGraph's `ToolNode` injects with the run's message history and thread id — the same material `ContractMiddleware` already read. A declared budget therefore binds on a plain `create_langchain_tools(...)` wiring, with no middleware and no manual `observe_tokens()` call.

| Path | Feeds `token_budget`? | |
|---|---|---|
| Pydantic AI tools / toolset | Yes | unchanged |
| LangChain `ContractMiddleware` | Yes | unchanged |
| **LangChain `create_langchain_tools`** | **Yes** | **this PR** |
| `contract_middleware`, Claude Agent SDK | No | genuinely blind — `args` dict only; still warn |

## The two open questions from the issue, settled

**Does the parameter leak into the advertised schema?** No. `infer_schema=False` means the schema is the JSON Schema dict verbatim, not the coroutine signature. Asserted by test (`tool.args == {"sql"}`), not assumed.

**Should a missing injection fail loudly?** No — the issue guessed wrong here. Injection happens inside a graph; `await tool.ainvoke({"sql": ...})` is a supported call shape that passes no runtime, and most of this repo's own tests use it. A required parameter would break every direct caller to catch a mis-wiring whose worst case is the *previous* behaviour: usage simply unobserved. So it is optional, defaulting to `None`.

## Shared, not copied

`_observe_usage` / `_usage_scope_for` are now module-level and keyed on `(state, config)` — the one shape both callers can produce — with the middleware methods reduced to unpackers. The issue flagged this explicitly: a duplicated envelope in `middleware.py` is what let a bug through in v0.32.0.

Fed the same run, both paths derive the same per-conversation scope key and observe the same cumulative total, so **wiring both does not double-count** — whichever runs second is a no-op. That property is what makes the tool-path observation safe to leave *unconditional* rather than gating it on `apply_middleware`, which governs enforcement, not observation. Covered by `test_tools_and_middleware_on_one_session_do_not_double_count`.

## Testing

35 tests in `test_langchain.py` (was 28), 893 total, all green. The tool path now mirrors the middleware's coverage: feeds on a real call, repeated calls do not multiply, two conversations do not erase each other, unthreaded conversations separate by message id, a breach blocks.

The load-bearing one is `test_budget_is_fed_through_a_real_agent`, which drives an actual `create_agent`. Every other test hands `runtime` over itself and **would still pass with injection completely broken** — injection hinges on `ToolNode` calling `get_type_hints()` over the coroutine, which needs `ToolRuntime` in module globals because the module uses `from __future__ import annotations`. Confirmed by mutation: moving that import into function scope fails this test and no other.

Also verified at the declared floors (langchain 1.2.17 / langchain-core 1.3.3 / langgraph 1.1.10, checked to be what actually resolved) — `ToolRuntime` and `ToolCallRequest.runtime` both exist there, so no floor bump.

## Compatibility

Additive. Existing calls unchanged, direct `ainvoke` still works, advertised arguments unchanged. **But a `token_budget` declared alongside `create_langchain_tools` now binds where it previously did not** — an aspirational budget will start raising `ToolException`. The v0.34.0 warning was the notice for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)