### PR TITLE
feat: contract_run_kwargs enforces token_budget exactly (v0.37.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **`contract_run_kwargs(contract, session)`** (Pydantic AI) — enforces `token_budget` exactly, where v0.36.0's `usage_limits_from_contract` only bounded it at roughly twice the declared ceiling. Returns both halves of the wiring, because they are only correct together:
+- **`contract_run_kwargs(contract, session)`** (Pydantic AI) — makes `token_budget` accounting exact, where v0.36.0's `usage_limits_from_contract` lets spend grow *linearly with the number of turns*. Returns both halves of the wiring, because they are only correct together:
 
   ```python
   await agent.run(prompt, **contract_run_kwargs(dc, session))
   # -> {"usage": <carried RunUsage>, "usage_limits": <flat ceiling>}
   ```
 
-  One `RunUsage` is carried across every `agent.run()` for the session, so Pydantic AI's own counter sees **every** request — including the answer generation after a run's last tool call, which the tool wrapper can never observe and whose omission is what made the previous helper approximate. Nothing is missed, so nothing is estimated. Measured on an agent spending 100 tokens per request against a 500-token budget: **true spend 600, against 1700 for the bounded helper over the same turns**. And a refused turn now **costs nothing** — with the whole history in the counter, `check_before_request` refuses before issuing a request, where the bounded helper's per-run counter started at zero and so bought one billed request on every refused turn, forever.
+  One `RunUsage` is carried across every `agent.run()` for the session, so Pydantic AI's own counter sees **every** request — including the answer generation after a run's last tool call, which the tool wrapper can never observe and whose omission is what made the previous helper approximate. Nothing is missed, so nothing is estimated. Measured on an agent spending 100 tokens per request against a 500-token budget: **true spend settles at 600 and stays flat however many turns run**, where the superseded helper is linear — 1100 at 6 turns, 1700 at 12, 2500 at 20. Flat-versus-linear is the real difference; any single pair of numbers understates it. The *accounting* is exact; spend still overshoots the ceiling by the requests in flight when it is crossed (600 against 500 here), which is a bounded overshoot rather than a growing one. And a refused turn now **costs nothing** — with the whole history in the counter, `check_before_request` refuses before issuing a request, where the bounded helper's per-run counter started at zero and so bought one billed request on every refused turn, forever.
 
 ### Design notes
 
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - **The counter lives in a module-private `WeakKeyDictionary` keyed on the session**, not on `ContractSession`: `RunUsage` is a Pydantic AI type and `core/` stays framework-agnostic. Weak keys because the caller owns session lifetime.
 - **The tool wrapper chooses its usage scope by identity, not a flag.** If `ctx.usage` *is* the counter registered for that session it accrues under one constant key; otherwise it falls back to `run_id`. So ignoring the helper, or passing its `usage_limits` without its `usage`, degrades to the older bounded behaviour instead of corrupting the tally — and no boolean exists to get wrong. This matters in both directions: treating a carried counter as per-run re-accrues the running total on every run, measured at **900 recorded against 600 truly spent**, and the inflated tally then blocked a run that was still within budget.
 - `session.tokens_used` still lags mid-run, since the wrapper only observes while a tool executes. `contract_run_kwargs` reconciles it at the start of each run, so between runs — when a caller would read it — it is the true spend.
+- **Adopt it from the start of a session.** The carried counter begins at zero and knows nothing of spend recorded before the first call — from a plain `agent.run` without these kwargs, from another adapter sharing the session, or from a direct `observe_tokens()`. The flat ceiling is measured against the counter alone, so that earlier spend is not deducted from it. In-tool `check_limits()` still sees the session's full tally and stops the next tool call, so this degrades rather than escapes; but mixing wirings mid-session gives up the exactness that is the point.
 
 ### Superseded
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.0] - 2026-08-03
+
+### Added
+
+- **`contract_run_kwargs(contract, session)`** (Pydantic AI) — enforces `token_budget` exactly, where v0.36.0's `usage_limits_from_contract` only bounded it at roughly twice the declared ceiling. Returns both halves of the wiring, because they are only correct together:
+
+  ```python
+  await agent.run(prompt, **contract_run_kwargs(dc, session))
+  # -> {"usage": <carried RunUsage>, "usage_limits": <flat ceiling>}
+  ```
+
+  One `RunUsage` is carried across every `agent.run()` for the session, so Pydantic AI's own counter sees **every** request — including the answer generation after a run's last tool call, which the tool wrapper can never observe and whose omission is what made the previous helper approximate. Nothing is missed, so nothing is estimated. Measured on an agent spending 100 tokens per request against a 500-token budget: **true spend 600, against 1700 for the bounded helper over the same turns**. And a refused turn now **costs nothing** — with the whole history in the counter, `check_before_request` refuses before issuing a request, where the bounded helper's per-run counter started at zero and so bought one billed request on every refused turn, forever.
+
+### Design notes
+
+- **The limit is flat, not the remainder.** The carried counter already holds the spend; subtracting it again would take it off twice and lock the run out below its own budget — the same double-subtraction `usage_limits_from_contract` warns about when combined with `agent.run(usage=...)`. Guarded by a test that spends first, because a fresh session cannot tell the two apart (`budget - 0 == budget`); found by mutation, which passed every other test in the file.
+- **The counter lives in a module-private `WeakKeyDictionary` keyed on the session**, not on `ContractSession`: `RunUsage` is a Pydantic AI type and `core/` stays framework-agnostic. Weak keys because the caller owns session lifetime.
+- **The tool wrapper chooses its usage scope by identity, not a flag.** If `ctx.usage` *is* the counter registered for that session it accrues under one constant key; otherwise it falls back to `run_id`. So ignoring the helper, or passing its `usage_limits` without its `usage`, degrades to the older bounded behaviour instead of corrupting the tally — and no boolean exists to get wrong. This matters in both directions: treating a carried counter as per-run re-accrues the running total on every run, measured at **900 recorded against 600 truly spent**, and the inflated tally then blocked a run that was still within budget.
+- `session.tokens_used` still lags mid-run, since the wrapper only observes while a tool executes. `contract_run_kwargs` reconciles it at the start of each run, so between runs — when a caller would read it — it is the true spend.
+
+### Superseded
+
+- **`usage_limits_from_contract` is superseded but still supported**, with no deprecation warning: it is one release old, remains correct for what it claims, and needs nothing but the limit — so it still suits a caller who cannot carry a counter across turns. Its docstring, the README and `docs/architecture.md` now point at `contract_run_kwargs` and state plainly that it bounds rather than enforces.
+
+### Compatibility
+
+- Additive and opt-in. Existing wiring is unchanged, including `usage_limits_from_contract`. Callers should still catch `ContractSessionLimitError` alongside `pydantic_ai.exceptions.UsageLimitExceeded`: the session continues to enforce `max_retries`, `cost_limit_usd` and `max_duration_seconds`, and still fires when fed from outside the run.
+- Sequential turns only. One carried counter per session is shared mutable state, so concurrent runs for the same user race on it — the same shape `ContractDeps` already describes for sessions.
+
 ## [0.36.0] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -959,44 +959,52 @@ nothing runs to check. And a sub-agent or subgraph inherits its parent's
 `thread_id`, so its own usage is under-counted rather than added; the budget
 binds on the parent's spend.
 
-**On Pydantic AI you can narrow the first of those** by letting the framework
-enforce per model request, which never needs a tool call to happen:
+**On Pydantic AI the budget is enforced properly**, by letting the framework
+check it on every model request — which never needs a tool call to happen:
 
 ```python
-from agentic_data_contracts import usage_limits_from_contract
+from agentic_data_contracts import contract_run_kwargs
 
 result = await agent.run(
     prompt,
     deps=ContractDeps(session=session),
-    usage_limits=usage_limits_from_contract(dc, session),  # per run, not once
+    **contract_run_kwargs(dc, session),   # -> usage= and usage_limits=
 )
 ```
 
-The session is required, and is the point: `UsageLimits` applies to one
-`agent.run()` while `token_budget` is a ceiling across every turn, so the helper
-limits each run to what the session has *left*. Passing the raw budget instead
-would re-grant it each turn — a 50,000-token contract authorising 50,000 *per
-turn*. `max_retries` is deliberately **not** mapped onto `request_limit`: ours
-counts blocked queries, theirs counts LLM calls.
+That returns both halves together because they are only correct together: one
+`RunUsage` carried across every turn for this session, plus the contract's
+budget as a flat ceiling. Pydantic AI's own counter then sees *every* request,
+including the answer generation the tools never observe, so nothing has to be
+estimated. Two things follow, both measured on a 500-token budget:
 
-Two things to know before adopting it:
+- **True spend lands just past the ceiling** — 600 rather than 1700 over the
+  same turns.
+- **A refused turn costs nothing**, because the check runs *before* the request
+  is issued.
 
-- **This bounds the budget, it does not enforce it exactly.** The session is fed
-  only from inside the tools, so model requests after a run's last tool call —
-  answer generation included — go uncounted, and each run is granted more than
-  it should be. Measured overshoot on a small test agent was ~2× *at the first
-  refusal*, and spend keeps climbing after that, because each refused turn still
-  costs one billed model request while the session's tally sits frozen. The
-  factor depends on how often your agent calls tools; an agent that calls none
-  is still unbounded across turns, though it is now stopped within a run.
-  Much better than the unbounded alternative, but plan for a ceiling, not a
-  number. [#56](https://github.com/flyersworder/agentic-data-contracts/issues/56)
-  tracks making it exact.
-- **Catch `pydantic_ai.exceptions.UsageLimitExceeded` as well as
-  `ContractSessionLimitError`** — not instead of it. The framework usually stops
-  the run first, but the contract-side exception still fires when the session is
-  fed from outside the run (a shared session, or your own `observe_tokens()`
-  call). Keep both handlers.
+`max_retries` is deliberately **not** mapped onto `request_limit`: ours counts
+blocked queries, theirs counts LLM calls.
+
+Keep catching `ContractSessionLimitError` alongside
+`pydantic_ai.exceptions.UsageLimitExceeded` — the session still enforces
+`max_retries`, `cost_limit_usd` and `max_duration_seconds`, and can be fed from
+outside the run. Sequential turns only: one counter per session is shared
+mutable state.
+
+<details>
+<summary><code>usage_limits_from_contract</code> — the earlier, weaker helper</summary>
+
+v0.36.0 shipped `usage_limits_from_contract(dc, session)`, which returns only a
+`UsageLimits` whose ceiling is the budget *minus what the session has recorded*.
+It still works and is still supported — it needs nothing but the limit, so it
+suits a caller who cannot carry a counter — but it **bounds** the budget rather
+than enforcing it. The session is fed only from inside the tools, so requests
+after a run's last tool call go uncounted and each run is granted a little too
+much: ~2× the ceiling at first refusal, climbing after that because every
+refused turn still buys one billed request. Prefer `contract_run_kwargs`.
+
+</details>
 
 ## Optional Dependencies
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ The caller owns each user's `ContractSession` (created once per user, keyed by
 user id). Per-user principals drive per-principal table/rule gating, and the same
 `ModelRetry` / `ContractSessionLimitError` enforcement applies per user.
 
-Pair with `usage_limits_from_contract(dc, user_session)` on each `run()` to have
+Pair with `**contract_run_kwargs(dc, user_session)` on each `run()` to have
 Pydantic AI enforce the token budget per model request — see
 [Resource Limits](#resource-limits).
 
@@ -978,8 +978,9 @@ budget as a flat ceiling. Pydantic AI's own counter then sees *every* request,
 including the answer generation the tools never observe, so nothing has to be
 estimated. Two things follow, both measured on a 500-token budget:
 
-- **True spend lands just past the ceiling** — 600 rather than 1700 over the
-  same turns.
+- **True spend settles rather than growing.** 600 against a 500-token budget,
+  and *flat* however many turns run — where the older helper is linear in
+  turns: 1100 at 6 turns, 1700 at 12, 2500 at 20.
 - **A refused turn costs nothing**, because the check runs *before* the request
   is issued.
 
@@ -999,10 +1000,11 @@ v0.36.0 shipped `usage_limits_from_contract(dc, session)`, which returns only a
 `UsageLimits` whose ceiling is the budget *minus what the session has recorded*.
 It still works and is still supported — it needs nothing but the limit, so it
 suits a caller who cannot carry a counter — but it **bounds** the budget rather
-than enforcing it. The session is fed only from inside the tools, so requests
-after a run's last tool call go uncounted and each run is granted a little too
-much: ~2× the ceiling at first refusal, climbing after that because every
-refused turn still buys one billed request. Prefer `contract_run_kwargs`.
+than enforcing it, and "bounds" flatters it: because each run is granted a
+remainder computed from a tally that misses whatever the previous run spent
+after its last tool call, spend grows **linearly with the number of turns** —
+~2× the ceiling at first refusal, 3.4× by 12 turns, 5× by 20. Prefer
+`contract_run_kwargs`.
 
 </details>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,43 +314,55 @@ checks. That is inherent to enforcing from inside tools, and identical to how
 `remaining()` reports honest `tokens_remaining` in every `run_query` response,
 which lets the model self-regulate.
 
-**Narrowing the window (Pydantic AI).** `usage_limits_from_contract(contract,
-session)` translates `token_budget` into a `UsageLimits` for `agent.run()`,
-which Pydantic AI checks on every model request — no tool call required, so
-*within a run* the blind case above disappears. The session argument is
-mandatory: `UsageLimits` is scoped to one `agent.run()` while a
-`ContractSession` spans every turn, so the helper limits each run to
-`token_budget - session.tokens_used`. Mapping the raw budget would re-grant it
-per turn — a 50,000-token contract authorising 500,000 across ten turns, which
-is the declared-but-unenforced shape this layer exists to prevent.
+**Closing the window (Pydantic AI).** `contract_run_kwargs(contract, session)`
+returns `{"usage", "usage_limits"}` for `agent.run()`: one `RunUsage` carried
+across every turn for that session, plus the contract's `token_budget` as a flat
+ceiling. Pydantic AI checks it on every model request — no tool call required —
+so the blind case above disappears, and because the counter spans turns it sees
+*every* request, including the answer generation the tools never observe.
+Nothing is missed, so nothing is estimated. Measured on a 500-token budget:
+true spend 600 rather than 1700, and a refused turn costs nothing because
+`check_before_request` fires before the request is issued.
 
-**It bounds the budget rather than enforcing it exactly**, and the reason is
-worth stating precisely. The subtracted figure is `session.tokens_used`, which
-is fed only from inside the tool wrapper, so every model request after a run's
-last tool call — including answer generation, usually the largest — is never
-observed. Each run is granted slightly more than the true remainder, and the
-shortfall compounds. Measured on a two-request-per-turn agent with a 500-token
-budget, real spend reached ~2× the ceiling by the first refusal. That factor is
-not a constant — it tracks the tool-call-to-request ratio (~1.4× measured for a
-three-tool-call turn), and an agent that calls **no** tools is unbounded across
-turns entirely, since `session.tokens_used` never leaves 0: 12 turns of a
-500-token budget spent 1200 with zero refusals. Within a run such an agent *is*
-now stopped, which is the hole this closes. The exact fix is to carry one
-`RunUsage` across turns via `agent.run(usage=...)`, so pydantic-ai's own counter
-sees every request; that needs a design pass (the carried counter is global
-while `observe_tokens` scopes per `run_id` and would double-count it) and is
-tracked as issue #56.
+Three details carry the design:
 
-Two knock-on effects. Callers should catch
-`pydantic_ai.exceptions.UsageLimitExceeded` **as well as**
-`ContractSessionLimitError` — not instead of it. The framework usually stops the
-run first, because a tool can only execute on a response that already passed
-`check_tokens`; but the contract-side exception still fires whenever the session
-is fed from outside the run, which a session shared with another adapter or a
-direct `observe_tokens()` call both do (verified on either `apply_middleware`
-value). And the session's tally freezes once runs start being refused, since no
-further tools execute to feed it — while each refused turn still costs one
-billed model request, so cumulative spend keeps climbing past that ~2×.
+- **The limit is flat, not the remainder.** The carried counter already holds
+  the spend; subtracting it again would take it off twice and lock the run out
+  below its budget. That is the same double-subtraction the older helper warns
+  against when combined with `usage=`.
+- **The counter lives in a module-private `WeakKeyDictionary` keyed on the
+  session**, not on `ContractSession` — `RunUsage` is a Pydantic AI type and
+  `core/` stays framework-agnostic. Weak keys because the caller owns session
+  lifetime and this must not be what keeps one alive.
+- **The tool wrapper picks its scope by identity**, not a flag: if `ctx.usage`
+  *is* the counter registered for this session it accrues under one constant
+  key, otherwise it falls back to `run_id`. So a caller who ignores the helper,
+  or passes its `usage_limits` without its `usage`, gets the older bounded
+  behaviour rather than a corrupted tally. Getting a boolean wrong is not a
+  failure mode because there is no boolean. Treating a carried counter as
+  per-run would inflate the session's tally and block runs still within budget —
+  measured at 900 recorded against 600 truly spent, before the identity check
+  existed.
+
+`session.tokens_used` still lags mid-run, since the wrapper only observes while
+a tool is executing; `contract_run_kwargs` reconciles it at the start of each
+run, so between runs — when a caller would read it — it is the true spend.
+
+Callers should catch `pydantic_ai.exceptions.UsageLimitExceeded` **as well as**
+`ContractSessionLimitError`, not instead of it: the session still enforces
+`max_retries`, `cost_limit_usd` and `max_duration_seconds`, and still fires when
+fed from outside the run (a shared session, or a direct `observe_tokens()`
+call, on either `apply_middleware` value).
+
+**The earlier helper.** `usage_limits_from_contract(contract, session)` returns
+only a `UsageLimits`, whose ceiling is the budget minus what the session has
+recorded. It is superseded but supported — it needs nothing but the limit, so it
+suits a caller who cannot carry a counter. It **bounds** rather than enforces:
+the subtracted figure misses everything after each run's last tool call, so the
+shortfall compounds to ~2× the ceiling at first refusal (the factor tracks the
+tool-call-to-request ratio; an agent calling no tools at all is unbounded across
+runs), and every refused turn still buys one billed request while the tally sits
+frozen.
 
 Two things are deliberately not mapped. `max_retries` must **not** become
 `request_limit`: ours counts blocked query attempts, theirs counts model
@@ -923,7 +935,7 @@ agentic-data-contracts/
 │   │   ├── middleware.py        # contract_middleware decorator
 │   │   ├── sdk.py               # Claude Agent SDK adapter (create_sdk_mcp_server)
 │   │   ├── langchain.py         # LangChain / deepagents adapter (create_langchain_tools)
-│   │   └── pydantic_ai.py       # Pydantic AI adapter (create_pydantic_ai_tools; create_pydantic_ai_toolset for one shared Agent across users; usage_limits_from_contract for per-request budget enforcement)
+│   │   └── pydantic_ai.py       # Pydantic AI adapter (create_pydantic_ai_tools; create_pydantic_ai_toolset for one shared Agent across users; contract_run_kwargs for exact per-request budget enforcement)
 │   ├── semantic/
 │   │   ├── __init__.py
 │   │   ├── base.py              # SemanticSource protocol

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,8 +321,10 @@ ceiling. Pydantic AI checks it on every model request — no tool call required 
 so the blind case above disappears, and because the counter spans turns it sees
 *every* request, including the answer generation the tools never observe.
 Nothing is missed, so nothing is estimated. Measured on a 500-token budget:
-true spend 600 rather than 1700, and a refused turn costs nothing because
-`check_before_request` fires before the request is issued.
+true spend settles at 600 and stays there however many turns run, where the
+superseded helper grows linearly with turns (1100 at 6, 1700 at 12, 2500 at
+20). A refused turn also costs nothing, because `check_before_request` fires
+before the request is issued.
 
 Three details carry the design:
 
@@ -357,12 +359,13 @@ call, on either `apply_middleware` value).
 **The earlier helper.** `usage_limits_from_contract(contract, session)` returns
 only a `UsageLimits`, whose ceiling is the budget minus what the session has
 recorded. It is superseded but supported — it needs nothing but the limit, so it
-suits a caller who cannot carry a counter. It **bounds** rather than enforces:
-the subtracted figure misses everything after each run's last tool call, so the
-shortfall compounds to ~2× the ceiling at first refusal (the factor tracks the
-tool-call-to-request ratio; an agent calling no tools at all is unbounded across
-runs), and every refused turn still buys one billed request while the tally sits
-frozen.
+suits a caller who cannot carry a counter. It does **not** bound the budget: the
+subtracted figure misses everything after each run's last tool call, so the
+shortfall compounds and spend grows linearly with turns — ~2× the ceiling at
+first refusal, 3.4× by 12 turns, 5× by 20. (The slope tracks the
+tool-call-to-request ratio; an agent calling no tools at all never accrues at
+all.) Every refused turn also still buys one billed request while the tally
+sits frozen.
 
 Two things are deliberately not mapped. `max_retries` must **not** become
 `request_limit`: ours counts blocked query attempts, theirs counts model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.36.0"
+version = "0.37.0"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/__init__.py
+++ b/src/agentic_data_contracts/__init__.py
@@ -42,12 +42,14 @@ except ImportError:  # pragma: no cover — exercised only without the extra
 try:
     from agentic_data_contracts.tools.pydantic_ai import (
         ContractDeps,
+        contract_run_kwargs,
         create_pydantic_ai_tools,
         create_pydantic_ai_toolset,
         usage_limits_from_contract,
     )
 except ImportError:  # pragma: no cover — exercised only without the extra
     ContractDeps = None  # ty: ignore[invalid-assignment]
+    contract_run_kwargs = None  # ty: ignore[invalid-assignment]
     create_pydantic_ai_tools = None  # ty: ignore[invalid-assignment]
     create_pydantic_ai_toolset = None  # ty: ignore[invalid-assignment]
     usage_limits_from_contract = None  # ty: ignore[invalid-assignment]
@@ -71,6 +73,7 @@ __all__ = [
     "contract_canonical_bytes",
     "contract_digest",
     "contract_middleware",
+    "contract_run_kwargs",
     "create_langchain_tools",
     "create_pydantic_ai_toolset",
     "create_pydantic_ai_tools",

--- a/src/agentic_data_contracts/tools/pydantic_ai.py
+++ b/src/agentic_data_contracts/tools/pydantic_ai.py
@@ -31,10 +31,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from pydantic_ai import ModelRetry, RunContext, Tool
 from pydantic_ai.toolsets import FunctionToolset, ToolsetFunc
-from pydantic_ai.usage import UsageLimits
+from pydantic_ai.usage import RunUsage, UsageLimits
 
 from agentic_data_contracts.adapters.base import DatabaseAdapter
 from agentic_data_contracts.core.contract import DataContract
@@ -53,6 +54,24 @@ from agentic_data_contracts.tools.factory import (
 )
 
 _BLOCKED_PREFIX = "BLOCKED —"
+
+# One carried ``RunUsage`` per ``ContractSession``, so a session's token tally
+# can track a counter that spans every turn instead of per-run snapshots. Weak
+# keys: the caller owns session lifetime (one per user, often held for a
+# conversation), and this must not be what keeps one alive.
+#
+# Module-private rather than an attribute on ``ContractSession`` deliberately —
+# ``RunUsage`` is a Pydantic AI type and ``core/`` stays framework-agnostic.
+# Keyed on identity, which is also how the tool wrapper decides whether the
+# counter it was handed is the carried one; see ``_carried_usage_scope``.
+_CARRIED_USAGE: WeakKeyDictionary[ContractSession, RunUsage] = WeakKeyDictionary()
+
+# Scope for a carried counter. Constant on purpose: the counter is already
+# global across the session's runs, so a per-run key would re-accrue the whole
+# running total on each new run. Measured before this existed: a true spend of
+# 600 was recorded as 900, and the inflated tally then blocked a run that was
+# still within budget.
+_CARRIED_SCOPE = "pydantic-ai:carried"
 # Substring marking a *terminal* session-budget breach inside a BLOCKED
 # envelope (vs. a recoverable validation/permission block). Both this adapter's
 # own pre-check and ``factory.run_query``'s self-check emit it, so the sniff
@@ -158,13 +177,9 @@ def _to_pydantic_ai_tool(
     async def _fn(ctx: RunContext[Any], **kwargs: Any) -> str:
         # Observe BEFORE the limit check, so a budget already exhausted by the
         # model's own consumption is caught on this call rather than the next.
-        # `run_id` scopes the observation: pydantic-ai reports usage
-        # cumulatively per run, and one session spans many. Skip rather than
-        # fall back to a shared key -- a constant scope collapses every run into
-        # max() and silently drops the smaller ones.
-        run_id = ctx.run_id
-        if run_id is not None and ctx.usage.total_tokens:
-            session.observe_tokens(ctx.usage.total_tokens, scope=str(run_id))
+        scope = _usage_scope(ctx, session)
+        if scope is not None and ctx.usage.total_tokens:
+            session.observe_tokens(ctx.usage.total_tokens, scope=scope)
 
         if apply_middleware:
             try:
@@ -202,10 +217,129 @@ def _to_pydantic_ai_tool(
     )
 
 
+def _usage_scope(ctx: RunContext[Any], session: ContractSession) -> str | None:
+    """Pick the key under which this run's usage total accrues, or ``None``.
+
+    ``observe_tokens`` accrues the delta *per scope*, so the key has to match
+    the span of the counter being read — and which counter that is depends on
+    how the caller wired the run:
+
+    - **Carried** (``contract_run_kwargs``): ``ctx.usage`` *is* the
+      ``RunUsage`` registered for this session, spanning every turn. One
+      constant key, so the running total accrues once.
+    - **Per run** (the default, and ``usage_limits_from_contract``):
+      ``ctx.usage`` restarts at zero each ``agent.run()``, so it is keyed by
+      ``run_id`` and each run contributes its own total.
+
+    Decided by **identity**, not a flag, and that is what makes mis-wiring
+    safe. A caller who ignores ``contract_run_kwargs``, or passes its
+    ``usage_limits`` without its ``usage``, simply fails the ``is`` check and
+    gets the per-run behaviour — bounded, exactly as before. The alternative
+    failure, treating a per-run counter as carried, would under-count; treating
+    a carried counter as per-run would inflate the tally and block runs still
+    within budget. Neither is reachable by getting a boolean wrong, because
+    there is no boolean.
+
+    ``None`` means "do not observe": no ``run_id`` and no carried counter
+    leaves nothing that identifies a span, and a shared fallback key would
+    collapse every run into ``max()`` and silently drop the smaller ones.
+    """
+    if _CARRIED_USAGE.get(session) is ctx.usage:
+        return _CARRIED_SCOPE
+    run_id = ctx.run_id
+    return str(run_id) if run_id is not None else None
+
+
+def contract_run_kwargs(
+    contract: DataContract, session: ContractSession
+) -> dict[str, Any]:
+    """Both halves of exact ``token_budget`` enforcement, for ``agent.run()``.
+
+    Supersedes :func:`usage_limits_from_contract`, which bounds the budget at
+    roughly twice the declared ceiling rather than enforcing it::
+
+        session = ContractSession(contract)          # one per user
+        tools = create_pydantic_ai_tools(contract, adapter=adapter,
+                                         session=session)
+
+        await agent.run(prompt, **contract_run_kwargs(contract, session))
+
+    Returns ``{"usage": ..., "usage_limits": ...}``. Splat it; the two are only
+    correct together, which is why they are returned together rather than as
+    two functions a caller could half-adopt.
+
+    **Why this is exact and the other is not.** ``usage_limits_from_contract``
+    subtracts ``session.tokens_used``, and the session is fed only from inside
+    the tool wrapper — so every model request after a run's last tool call, the
+    final answer included, goes unobserved and the shortfall compounds. Here the
+    same ``RunUsage`` is carried across every ``agent.run()`` for the session, so
+    Pydantic AI's own counter sees *every* request, and the tool wrapper reads
+    that one running total. Nothing is missed, so nothing has to be estimated.
+
+    Two consequences follow, both measured on an agent spending 100 tokens per
+    request against a 500-token budget:
+
+    - **True spend lands just past the ceiling instead of at a multiple of it**
+      — 600 rather than 1700 over the same turns.
+    - **A refused turn costs nothing.** With the whole history in the counter,
+      ``check_before_request`` refuses *before* issuing a request. The bounded
+      helper cannot do this: its per-run counter starts at zero, so every
+      refused turn still bought one billed model request, forever.
+
+    The limit is **flat** (``total_tokens_limit=token_budget``), not the
+    remainder. Subtracting would take the spend off twice — once in the limit
+    and once inside the carried counter — and lock the run out below its budget.
+    That is exactly why ``usage_limits_from_contract``'s docstring says not to
+    combine it with ``agent.run(usage=...)``.
+
+    Still call it **per run**. The counter is stable, but the ``UsageLimits`` is
+    rebuilt each time so a contract reloaded mid-conversation takes effect —
+    and hoisting it is no longer a correctness bug the way it was when the
+    limit carried a snapshot of spend.
+
+    A contract with no ``token_budget`` gets a carried counter and no token
+    ceiling: usage is then tracked honestly for ``remaining()`` without
+    inventing a limit nothing declared.
+
+    ``ContractSessionLimitError`` remains reachable — the session still holds
+    ``max_retries``, ``cost_limit_usd`` and ``max_duration_seconds``, and can be
+    fed from outside the run — so keep that handler alongside
+    ``pydantic_ai.exceptions.UsageLimitExceeded``.
+
+    Sequential turns only. One counter per session is shared mutable state, so
+    concurrent runs for the same user race on it; that is the same shape
+    :class:`ContractDeps` already describes for sessions themselves.
+    """
+    usage = _CARRIED_USAGE.get(session)
+    if usage is None:
+        usage = RunUsage()
+        _CARRIED_USAGE[session] = usage
+    elif usage.total_tokens:
+        # Catch the session up before the next run starts. The tool wrapper can
+        # only observe while a tool is executing, so it always misses whatever
+        # the previous run spent after its last tool call -- the final answer
+        # most of all. Enforcement does not depend on this (the carried counter
+        # is what Pydantic AI checks), but `remaining()` is reported to the
+        # model in every run_query response, and a tally that lags by the
+        # largest request of each turn is a number the model would act on.
+        session.observe_tokens(usage.total_tokens, scope=_CARRIED_SCOPE)
+
+    resources = contract.schema.resources
+    budget = resources.token_budget if resources is not None else None
+    limits = UsageLimits() if budget is None else UsageLimits(total_tokens_limit=budget)
+    return {"usage": usage, "usage_limits": limits}
+
+
 def usage_limits_from_contract(
     contract: DataContract, session: ContractSession
 ) -> UsageLimits:
     """Translate a contract's ``token_budget`` into Pydantic AI ``UsageLimits``.
+
+    **Superseded by :func:`contract_run_kwargs`**, which enforces the budget
+    instead of bounding it at roughly twice the declared ceiling, and makes a
+    refused turn cost nothing. Prefer it. This remains supported and correct
+    for what it claims — it needs nothing but the limit, so it still suits a
+    caller who cannot carry a counter across turns.
 
     Closes the window that in-tool enforcement cannot::
 

--- a/src/agentic_data_contracts/tools/pydantic_ai.py
+++ b/src/agentic_data_contracts/tools/pydantic_ai.py
@@ -63,7 +63,7 @@ _BLOCKED_PREFIX = "BLOCKED —"
 # Module-private rather than an attribute on ``ContractSession`` deliberately —
 # ``RunUsage`` is a Pydantic AI type and ``core/`` stays framework-agnostic.
 # Keyed on identity, which is also how the tool wrapper decides whether the
-# counter it was handed is the carried one; see ``_carried_usage_scope``.
+# counter it was handed is the carried one; see ``_usage_scope``.
 _CARRIED_USAGE: WeakKeyDictionary[ContractSession, RunUsage] = WeakKeyDictionary()
 
 # Scope for a carried counter. Constant on purpose: the counter is already
@@ -167,10 +167,9 @@ def _to_pydantic_ai_tool(
     into a dict is safe.
 
     ``takes_ctx=True`` so the wrapper can read ``ctx.usage`` — this is the only
-    place the contract's ``token_budget`` can be fed on this path. Pydantic AI
-    reports usage cumulatively *per run*, while a session may span many runs
-    (see :class:`ContractDeps`), so ``ctx.run_id`` scopes it and
-    ``observe_tokens`` accrues the delta.
+    place the contract's ``token_budget`` can be fed on this path. Which span
+    that reading belongs to depends on how the caller wired the run, so the key
+    it accrues under is chosen by :func:`_usage_scope` rather than fixed here.
     """
     inner = tool_def.callable
 
@@ -255,8 +254,8 @@ def contract_run_kwargs(
 ) -> dict[str, Any]:
     """Both halves of exact ``token_budget`` enforcement, for ``agent.run()``.
 
-    Supersedes :func:`usage_limits_from_contract`, which bounds the budget at
-    roughly twice the declared ceiling rather than enforcing it::
+    Supersedes :func:`usage_limits_from_contract`, whose spend grows linearly
+    with the number of turns rather than settling at the declared ceiling::
 
         session = ContractSession(contract)          # one per user
         tools = create_pydantic_ai_tools(contract, adapter=adapter,
@@ -279,8 +278,10 @@ def contract_run_kwargs(
     Two consequences follow, both measured on an agent spending 100 tokens per
     request against a 500-token budget:
 
-    - **True spend lands just past the ceiling instead of at a multiple of it**
-      — 600 rather than 1700 over the same turns.
+    - **True spend settles instead of growing.** 600 against a 500-token
+      budget and *flat* however many turns run, where the superseded helper is
+      linear in turns: 1100 at 6, 1700 at 12, 2500 at 20. Flat-versus-linear is
+      the real difference; any single pair of numbers understates it.
     - **A refused turn costs nothing.** With the whole history in the counter,
       ``check_before_request`` refuses *before* issuing a request. The bounded
       helper cannot do this: its per-run counter starts at zero, so every
@@ -306,9 +307,22 @@ def contract_run_kwargs(
     fed from outside the run — so keep that handler alongside
     ``pydantic_ai.exceptions.UsageLimitExceeded``.
 
+    **Adopt it from the start of a session.** The carried counter begins at
+    zero and knows nothing of spend the session recorded before the first call
+    — from a plain ``agent.run`` without these kwargs, from another adapter
+    sharing the session, or from a direct ``observe_tokens()``. The flat
+    ceiling is then measured against the counter alone, so that earlier spend
+    is not deducted. In-tool ``check_limits()`` still sees the session's full
+    tally and stops the next tool call, so this degrades rather than escapes,
+    but mixing wirings mid-session gives up the exactness that is the whole
+    point of this helper.
+
     Sequential turns only. One counter per session is shared mutable state, so
     concurrent runs for the same user race on it; that is the same shape
-    :class:`ContractDeps` already describes for sessions themselves.
+    :class:`ContractDeps` already describes for sessions themselves. The
+    registration below is likewise get-then-set, so two threads calling this
+    for the *same new* session both build a counter and one wins — the loser's
+    run falls back to per-run scoping, which under-counts rather than inflating.
     """
     usage = _CARRIED_USAGE.get(session)
     if usage is None:
@@ -335,11 +349,15 @@ def usage_limits_from_contract(
 ) -> UsageLimits:
     """Translate a contract's ``token_budget`` into Pydantic AI ``UsageLimits``.
 
-    **Superseded by :func:`contract_run_kwargs`**, which enforces the budget
-    instead of bounding it at roughly twice the declared ceiling, and makes a
-    refused turn cost nothing. Prefer it. This remains supported and correct
-    for what it claims — it needs nothing but the limit, so it still suits a
-    caller who cannot carry a counter across turns.
+    **Superseded by :func:`contract_run_kwargs`.** The ceiling here is not a
+    ceiling: spend grows *linearly with the number of turns* — measured at
+    2.2x the budget by 6 turns, 3.4x by 12, 5.0x by 20 — because each run is
+    granted a remainder computed from a tally that misses whatever the previous
+    run spent after its last tool call. ``contract_run_kwargs`` is flat at 1.2x
+    no matter how many turns run, and makes a refused turn cost nothing. Prefer
+    it. This remains supported and correct for what it claims — it needs
+    nothing but the limit, so it still suits a caller who cannot carry a
+    counter across turns.
 
     Closes the window that in-tool enforcement cannot::
 

--- a/tests/test_tools/test_pydantic_ai.py
+++ b/tests/test_tools/test_pydantic_ai.py
@@ -30,6 +30,7 @@ from agentic_data_contracts.tools.factory import create_tools  # noqa: E402
 from agentic_data_contracts.tools.pydantic_ai import (  # noqa: E402
     ContractDeps,
     _unwrap_mcp_text,
+    contract_run_kwargs,
     create_pydantic_ai_tools,
     create_pydantic_ai_toolset,
     usage_limits_from_contract,
@@ -907,3 +908,195 @@ async def test_a_fresh_budget_does_not_stop_a_run() -> None:
         usage_limits=usage_limits_from_contract(contract, session),
     )
     assert result.output
+
+
+# ─── contract_run_kwargs — exact enforcement (v0.37.0) ────────────────────────
+
+
+def _tool_calling_model(spend: list[int]) -> Any:
+    """A model that calls one tool, then answers. Appends per-request spend."""
+    from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+    from pydantic_ai.usage import RequestUsage
+
+    def _fn(messages: list[Any], info: AgentInfo) -> ModelResponse:
+        spend.append(100)
+        usage = RequestUsage(input_tokens=50, output_tokens=50)
+        called = any(
+            getattr(part, "part_kind", "") == "tool-return"
+            for message in messages
+            for part in getattr(message, "parts", [])
+        )
+        if called:
+            return ModelResponse(parts=[TextPart("done")], usage=usage)
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "describe_table", {"schema": "analytics", "table": "orders"}
+                )
+            ],
+            usage=usage,
+        )
+
+    return FunctionModel(_fn)
+
+
+def test_run_kwargs_returns_both_halves_paired() -> None:
+    """The pairing is the point: one call, both keys, impossible to half-wire."""
+    from pydantic_ai.usage import RunUsage
+
+    contract = _budgeted_contract()
+    kwargs = contract_run_kwargs(contract, ContractSession(contract))
+
+    assert set(kwargs) == {"usage", "usage_limits"}
+    assert isinstance(kwargs["usage"], RunUsage)
+    assert kwargs["usage_limits"].total_tokens_limit == 50_000
+
+
+def test_run_kwargs_limit_stays_flat_after_the_session_has_spent() -> None:
+    """The double-subtraction footgun, guarded rather than only documented.
+
+    A fresh session cannot catch this: ``budget - 0 == budget``, so the
+    subtracting and flat versions agree and the bug ships. Spending first is
+    what separates them. Subtracting here would take the spend off twice —
+    once in the limit, once inside the carried counter — and lock the run out
+    below its declared budget.
+
+    Found by mutation: replacing the flat limit with a subtracting one passed
+    every other test in this file.
+    """
+    contract = _budgeted_contract()
+    session = ContractSession(contract)
+    kwargs = contract_run_kwargs(contract, session)
+    kwargs["usage"].input_tokens = 30_000  # a previous turn, on the carried counter
+
+    again = contract_run_kwargs(contract, session)
+    assert session.tokens_used == 30_000  # the session was reconciled...
+    assert again["usage_limits"].total_tokens_limit == 50_000  # ...the limit was not
+
+
+def test_run_kwargs_carries_the_same_counter_across_turns() -> None:
+    # One counter per session, or it is not carried at all.
+    contract = _budgeted_contract()
+    session = ContractSession(contract)
+
+    first = contract_run_kwargs(contract, session)["usage"]
+    second = contract_run_kwargs(contract, session)["usage"]
+    assert first is second
+
+    other = contract_run_kwargs(contract, ContractSession(contract))["usage"]
+    assert other is not first
+
+
+@pytest.mark.asyncio
+async def test_carried_counter_enforces_the_budget_exactly(
+    adapter: DuckDBAdapter,
+) -> None:
+    """The whole point of #56: the session tracks true spend, not an under-count.
+
+    Under the v0.36.0 snapshot design the session is fed per-run deltas and
+    misses everything after a run's last tool call. With a carried counter the
+    tool wrapper observes one global running total under a stable scope, so
+    ``session.tokens_used`` equals what was actually spent — no drift to
+    compound, and no false positive from double-counting either.
+    """
+    from pydantic_ai.exceptions import UsageLimitExceeded
+
+    budget = 500
+    contract = _budgeted_contract(budget)
+    session = ContractSession(contract)
+    spend: list[int] = []
+    agent = Agent(
+        _tool_calling_model(spend),
+        tools=create_pydantic_ai_tools(contract, adapter=adapter, session=session),
+    )
+
+    refused = 0
+    for _ in range(8):
+        try:
+            await agent.run("go", **contract_run_kwargs(contract, session))
+        except UsageLimitExceeded:
+            refused += 1
+
+    assert refused, "the framework must refuse once the budget is gone"
+
+    # Exact, with one caveat about *when*. The tool wrapper can only observe
+    # while a tool is executing, so mid-run it still lags by whatever the
+    # current turn spent after its last tool call. `contract_run_kwargs`
+    # reconciles at the start of the next run, so between runs — which is when
+    # a caller would read it — the tally is the true spend, not an estimate.
+    contract_run_kwargs(contract, session)
+    assert session.tokens_used == sum(spend)
+
+    # True spend overshoots by the requests already in flight when the ceiling
+    # was crossed, not by a multiple of the budget: ~1.2x here against ~3.4x
+    # measured for the bounded helper over the same turns.
+    assert sum(spend) <= budget + 200
+
+
+@pytest.mark.asyncio
+async def test_refused_turns_cost_nothing_once_the_budget_is_gone(
+    adapter: DuckDBAdapter,
+) -> None:
+    """The other half of the win, and the one a bound cannot give you.
+
+    ``check_before_request`` sees a carried total already past the limit and
+    refuses *before* issuing a request. Under the bounded design each refused
+    turn still bought one billed model request, forever.
+    """
+    from pydantic_ai.exceptions import UsageLimitExceeded
+
+    contract = _budgeted_contract(500)
+    session = ContractSession(contract)
+    spend: list[int] = []
+    agent = Agent(
+        _tool_calling_model(spend),
+        tools=create_pydantic_ai_tools(contract, adapter=adapter, session=session),
+    )
+
+    while True:
+        try:
+            await agent.run("go", **contract_run_kwargs(contract, session))
+        except UsageLimitExceeded:
+            break
+
+    settled = len(spend)
+    for _ in range(5):
+        with pytest.raises(UsageLimitExceeded):
+            await agent.run("go", **contract_run_kwargs(contract, session))
+
+    assert len(spend) == settled, "a refused turn must not issue a model request"
+
+
+@pytest.mark.asyncio
+async def test_ignoring_the_helper_degrades_rather_than_corrupts(
+    adapter: DuckDBAdapter,
+) -> None:
+    """Mis-wiring must fail safe.
+
+    The wrapper switches to the stable scope only when ``ctx.usage`` *is* the
+    counter registered for this session. A caller who passes a limit but no
+    carried counter therefore gets v0.36.0's per-run scoping — bounded, not
+    double-counted, which is the failure this design must not reintroduce.
+    """
+    from pydantic_ai.exceptions import UsageLimitExceeded
+
+    contract = _budgeted_contract(500)
+    session = ContractSession(contract)
+    spend: list[int] = []
+    agent = Agent(
+        _tool_calling_model(spend),
+        tools=create_pydantic_ai_tools(contract, adapter=adapter, session=session),
+    )
+
+    for _ in range(6):
+        try:
+            await agent.run(
+                "go", usage_limits=usage_limits_from_contract(contract, session)
+            )
+        except (UsageLimitExceeded, ContractSessionLimitError):
+            break
+
+    # Under-counts (the documented v0.36.0 bound); never over-counts, which is
+    # what would stop a run that is still within budget.
+    assert session.tokens_used <= sum(spend)

--- a/tests/test_tools/test_pydantic_ai.py
+++ b/tests/test_tools/test_pydantic_ai.py
@@ -30,6 +30,7 @@ from agentic_data_contracts.tools.factory import create_tools  # noqa: E402
 from agentic_data_contracts.tools.pydantic_ai import (  # noqa: E402
     ContractDeps,
     _unwrap_mcp_text,
+    _usage_scope,
     contract_run_kwargs,
     create_pydantic_ai_tools,
     create_pydantic_ai_toolset,
@@ -1028,9 +1029,11 @@ async def test_carried_counter_enforces_the_budget_exactly(
     contract_run_kwargs(contract, session)
     assert session.tokens_used == sum(spend)
 
-    # True spend overshoots by the requests already in flight when the ceiling
-    # was crossed, not by a multiple of the budget: ~1.2x here against ~3.4x
-    # measured for the bounded helper over the same turns.
+    # True spend overshoots only by the requests already in flight when the
+    # ceiling was crossed, and then STOPS -- running more turns does not spend
+    # more. The superseded helper grows linearly instead: 2.6x over these same
+    # 8 turns, 3.4x over 12, 5x over 20. Flat-versus-linear is the property;
+    # the tolerance below just pins the one-run overshoot.
     assert sum(spend) <= budget + 200
 
 
@@ -1100,3 +1103,69 @@ async def test_ignoring_the_helper_degrades_rather_than_corrupts(
     # Under-counts (the documented v0.36.0 bound); never over-counts, which is
     # what would stop a run that is still within budget.
     assert session.tokens_used <= sum(spend)
+
+
+def test_carried_counter_is_matched_by_identity_not_equality() -> None:
+    """``is``, not ``==`` — and the difference is reachable in principle.
+
+    ``RunUsage`` compares structurally, so a *copy* of the carried counter is
+    ``==`` to it while being a different object with its own future. Matching
+    by equality would treat that copy as carried and accrue it under the shared
+    key, under-counting every run that used it.
+
+    Found by mutation: swapping ``is`` for ``==`` passed every other test here,
+    because through a real ``agent.run`` the counter has already advanced by
+    tool-call time and equality breaks on its own. That makes this a property
+    worth pinning directly rather than relying on a coincidence of timing.
+    """
+    import copy
+
+    contract = _budgeted_contract()
+    session = ContractSession(contract)
+    carried = contract_run_kwargs(contract, session)["usage"]
+    twin = copy.copy(carried)
+
+    assert twin == carried  # structurally equal ...
+    assert twin is not carried  # ... but not the registered object
+
+    ctx = RunContext(deps=None, model=TestModel(), usage=twin, run_id="run-xyz")
+    assert _usage_scope(ctx, session) == "run-xyz"
+
+    same = RunContext(deps=None, model=TestModel(), usage=carried, run_id="run-xyz")
+    assert _usage_scope(same, session) == "pydantic-ai:carried"
+
+
+def test_run_kwargs_without_a_budget_still_carries_a_counter() -> None:
+    """No declared ceiling is not the same as no accounting.
+
+    ``remaining()`` and the other session limits still want an honest tally, so
+    the counter is carried either way; only the token ceiling is omitted, since
+    inventing one nothing declared is the failure this library exists to catch.
+    """
+    from pydantic_ai.usage import RunUsage
+
+    contract = _budgeted_contract(budget=None)
+    kwargs = contract_run_kwargs(contract, ContractSession(contract))
+
+    assert isinstance(kwargs["usage"], RunUsage)
+    assert kwargs["usage_limits"].total_tokens_limit is None
+
+
+def test_contract_session_stays_usable_as_a_weak_key() -> None:
+    """Pins the coupling that ``_CARRIED_USAGE`` depends on but cannot see.
+
+    ``core/session.py`` has no reason to know this module exists, so adding
+    ``__slots__`` without ``__weakref__``, or ``__eq__`` without ``__hash__``,
+    would break the registry from a file whose author had no way to know. This
+    fails there rather than at a user's first carried run.
+    """
+    import weakref
+
+    contract = _budgeted_contract()
+    session = ContractSession(contract)
+
+    assert weakref.ref(session)() is session
+    # Identity keying, not equality: two sessions on one contract are distinct
+    # budgets and must never share a counter.
+    assert ContractSession.__hash__ is object.__hash__
+    assert ContractSession(contract) != session

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #56.

v0.36.0 **bounded** `token_budget` at ~2× the declared ceiling. This **enforces** it.

```python
await agent.run(prompt, **contract_run_kwargs(dc, session))
# -> {"usage": <carried RunUsage>, "usage_limits": <flat ceiling>}
```

## Why the previous one could only approximate

`usage_limits_from_contract` subtracts `session.tokens_used`, and the session is fed only from inside the tool wrapper — so every model request after a run's last tool call, the final answer most of all, went unobserved, and the shortfall compounded per turn.

Carrying one `RunUsage` across every run for the session fixes it at the source: pydantic-ai's own counter sees **every** request, so the limit is flat against a total that is already complete. Nothing is missed, so nothing is estimated.

Measured, 100 tokens/request against a 500-token budget:

| | bounded (v0.36.0) | exact (this PR) |
|---|---|---|
| true spend over the same turns | 1700 (3.4×) | **600 (1.2×)** |
| cost of a refused turn | one billed request, forever | **nothing** |

The second row is the one a bound can't give you: with the whole history in the counter, `check_before_request` refuses *before* issuing a request.

## The blocker #56 named, solved by identity rather than a flag

#56 flagged that `observe_tokens`' per-`run_id` scope re-accrues a global counter. The wrapper now decides by identity: if `ctx.usage` **is** the counter registered for this session, one constant scope; otherwise `run_id`, as before.

So a caller who ignores the helper — or passes its `usage_limits` without its `usage` — degrades to v0.36.0's bounded behaviour rather than corrupting the tally, and **there is no boolean to get wrong**. That direction matters more than it looks: treating a carried counter as per-run recorded **900 against a true 600**, and the inflated tally then blocked a run that was still within budget. Over-enforcement, not under.

The counter lives in a module-private `WeakKeyDictionary` keyed on the session, not on `ContractSession` — `RunUsage` is a pydantic-ai type and `core/` stays framework-agnostic. Weak keys because the caller owns session lifetime.

## Both halves from one call, deliberately

They are only correct together: the limit must be **flat**, because subtracting spend the carried counter already holds takes it off twice and locks the run out below its own budget.

That one nearly shipped. **Mutation testing caught the subtracting variant passing every test in the file** — a fresh session cannot tell them apart, since `budget - 0 == budget`. Now guarded by a test that spends first.

## Accounting

`session.tokens_used` still lags mid-run, since the wrapper only observes while a tool executes. `contract_run_kwargs` reconciles at the start of each run, so between runs — when a caller would read it — it is the true spend. That matters because `remaining()` goes to the model in every `run_query` response.

## Supersession

`usage_limits_from_contract` is **superseded, not deprecated** — one release old, still correct for what it claims, and it needs nothing but the limit, so it still suits a caller who cannot carry a counter. Its docstring, the README and `docs/architecture.md` point at the replacement and say plainly that it bounds rather than enforces.

## Testing

910 tests, all green; verified at the declared floor (pydantic-ai-slim 2.0.0). Three mutations killed: identity check never matching, counter never registered, and the flat limit replaced by a subtracting one. Coverage includes exactness through a real multi-turn agent, refused turns costing nothing, and mis-wiring degrading rather than corrupting.

## Compatibility

Additive and opt-in; existing wiring including `usage_limits_from_contract` is unchanged. Keep catching `ContractSessionLimitError` alongside `UsageLimitExceeded` — the session still enforces `max_retries`, `cost_limit_usd` and `max_duration_seconds`. Sequential turns only: one carried counter per session is shared mutable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
