### PR TITLE
feat!: remove usage_limits_from_contract (v0.38.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.0] - 2026-08-03
+
+### Removed
+
+- **`usage_limits_from_contract()` is deleted.** Added in v0.36.0 and superseded by `contract_run_kwargs()` in v0.37.0 — **28 minutes later**, by release timestamp. It has no remaining use case, and keeping it was actively harmful rather than merely untidy.
+
+  The justification for keeping it was that it "suits a caller who cannot carry a counter across turns". That describes an empty set: every Pydantic AI run API accepting `usage_limits=` also accepts `usage=` — `run`, `run_sync`, `run_stream`, `run_stream_events`, `iter`. There is no call path where the limit can be passed but the counter cannot, so there was never a caller the older helper served and the newer one does not.
+
+  Meanwhile the two behave differently in a way a reader cannot see from the signatures: `usage_limits_from_contract` derives each run's allowance from `session.tokens_used`, which misses every model request after a run's last tool call, so spend grows **linearly with turns** — 2.2× the declared budget at 6 turns, 3.4× at 12, 5.0× at 20. `contract_run_kwargs` is flat at 1.2× regardless. Offering both meant the README presented two ways to do one thing where the simpler-looking one silently under-enforces — the exact failure class v0.32.0–v0.37.0 have been removing, reintroduced as a menu choice.
+
+  Removed outright rather than deprecated: a deprecation window's value scales with adoption, and a symbol that was the latest release for 28 minutes has none to speak of. This is a `0.x` project at Beta status, where SemVer permits a breaking change in a minor bump.
+
+  **Migration** — one line, and it strictly improves enforcement:
+
+  ```diff
+  - usage_limits=usage_limits_from_contract(dc, session),
+  + **contract_run_kwargs(dc, session),
+  ```
+
+### Changed
+
+- **The `max_retries` → `request_limit` caveat moved to `contract_run_kwargs`,** along with the `cost_limit_usd` / `max_duration_seconds` note, the zero-versus-absent budget distinction, and the `dataclasses.replace` composition path. These lived only in the deleted docstring. The caveat is a property of translating contracts into `UsageLimits` at all, not of whichever function does it — `max_retries` counts *blocked query attempts* here while `request_limit` counts *model requests*, and conflating them would silently redefine existing contracts. Its guarding test moved too.
+
+### Compatibility
+
+- **Breaking**, for anyone who adopted `usage_limits_from_contract` during the 28 minutes it was current. `from agentic_data_contracts import usage_limits_from_contract` now raises `ImportError`. The replacement is a one-line change and enforces the budget more tightly.
+
 ## [0.37.0] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - **`usage_limits_from_contract()` is deleted.** Added in v0.36.0 and superseded by `contract_run_kwargs()` in v0.37.0 — **28 minutes later**, by release timestamp. It has no remaining use case, and keeping it was actively harmful rather than merely untidy.
 
-  The justification for keeping it was that it "suits a caller who cannot carry a counter across turns". That describes an empty set: every Pydantic AI run API accepting `usage_limits=` also accepts `usage=` — `run`, `run_sync`, `run_stream`, `run_stream_events`, `iter`. There is no call path where the limit can be passed but the counter cannot, so there was never a caller the older helper served and the newer one does not.
+  The justification for keeping it was that it "suits a caller who cannot carry a counter across turns". That describes an empty set: every Pydantic AI run API accepting `usage_limits=` also accepts `usage=` — all six of `run`, `run_sync`, `run_stream`, `run_stream_sync`, `run_stream_events`, `iter`. There is no call path where the limit can be passed but the counter cannot, so there was never a caller the older helper served and the newer one does not.
 
   Meanwhile the two behave differently in a way a reader cannot see from the signatures: `usage_limits_from_contract` derives each run's allowance from `session.tokens_used`, which misses every model request after a run's last tool call, so spend grows **linearly with turns** — 2.2× the declared budget at 6 turns, 3.4× at 12, 5.0× at 20. `contract_run_kwargs` is flat at 1.2× regardless. Offering both meant the README presented two ways to do one thing where the simpler-looking one silently under-enforces — the exact failure class v0.32.0–v0.37.0 have been removing, reintroduced as a menu choice.
 
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
   - usage_limits=usage_limits_from_contract(dc, session),
   + **contract_run_kwargs(dc, session),
   ```
+
+  One caveat when migrating a **live** session: the carried counter starts at zero, so spend that session already recorded under the old wiring is not deducted from the flat ceiling. In-tool `check_limits()` still sees the full tally and stops the next tool call, so this degrades rather than escapes — but a fresh session per user is the clean way to adopt it.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -993,21 +993,6 @@ Keep catching `ContractSessionLimitError` alongside
 outside the run. Sequential turns only: one counter per session is shared
 mutable state.
 
-<details>
-<summary><code>usage_limits_from_contract</code> — the earlier, weaker helper</summary>
-
-v0.36.0 shipped `usage_limits_from_contract(dc, session)`, which returns only a
-`UsageLimits` whose ceiling is the budget *minus what the session has recorded*.
-It still works and is still supported — it needs nothing but the limit, so it
-suits a caller who cannot carry a counter — but it **bounds** the budget rather
-than enforcing it, and "bounds" flatters it: because each run is granted a
-remainder computed from a tally that misses whatever the previous run spent
-after its last tool call, spend grows **linearly with the number of turns** —
-~2× the ceiling at first refusal, 3.4× by 12 turns, 5× by 20. Prefer
-`contract_run_kwargs`.
-
-</details>
-
 ## Optional Dependencies
 
 | Extra | Package | Purpose |

--- a/README.md
+++ b/README.md
@@ -979,8 +979,10 @@ including the answer generation the tools never observe, so nothing has to be
 estimated. Two things follow, both measured on a 500-token budget:
 
 - **True spend settles rather than growing.** 600 against a 500-token budget,
-  and *flat* however many turns run — where the older helper is linear in
-  turns: 1100 at 6 turns, 1700 at 12, 2500 at 20.
+  and *flat* however many turns run. Deriving each run's allowance from the
+  session's own tally instead is linear in turns — 1100 at 6 turns, 1700 at 12,
+  2500 at 20 — because that tally never sees what a run spends after its last
+  tool call.
 - **A refused turn costs nothing**, because the check runs *before* the request
   is issued.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,17 +356,6 @@ Callers should catch `pydantic_ai.exceptions.UsageLimitExceeded` **as well as**
 fed from outside the run (a shared session, or a direct `observe_tokens()`
 call, on either `apply_middleware` value).
 
-**The earlier helper.** `usage_limits_from_contract(contract, session)` returns
-only a `UsageLimits`, whose ceiling is the budget minus what the session has
-recorded. It is superseded but supported — it needs nothing but the limit, so it
-suits a caller who cannot carry a counter. It does **not** bound the budget: the
-subtracted figure misses everything after each run's last tool call, so the
-shortfall compounds and spend grows linearly with turns — ~2× the ceiling at
-first refusal, 3.4× by 12 turns, 5× by 20. (The slope tracks the
-tool-call-to-request ratio; an agent calling no tools at all never accrues at
-all.) Every refused turn also still buys one billed request while the tally
-sits frozen.
-
 Two things are deliberately not mapped. `max_retries` must **not** become
 `request_limit`: ours counts blocked query attempts, theirs counts model
 requests, and conflating them would silently redefine existing contracts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,17 +321,18 @@ ceiling. Pydantic AI checks it on every model request — no tool call required 
 so the blind case above disappears, and because the counter spans turns it sees
 *every* request, including the answer generation the tools never observe.
 Nothing is missed, so nothing is estimated. Measured on a 500-token budget:
-true spend settles at 600 and stays there however many turns run, where the
-superseded helper grows linearly with turns (1100 at 6, 1700 at 12, 2500 at
-20). A refused turn also costs nothing, because `check_before_request` fires
-before the request is issued.
+true spend settles at 600 and stays there however many turns run. Deriving
+each run's allowance from the session's own tally instead grows linearly with
+turns (1100 at 6, 1700 at 12, 2500 at 20), because that tally never sees what a
+run spends after its last tool call. A refused turn also costs nothing, because
+`check_before_request` fires before the request is issued.
 
 Three details carry the design:
 
 - **The limit is flat, not the remainder.** The carried counter already holds
   the spend; subtracting it again would take it off twice and lock the run out
-  below its budget. That is the same double-subtraction the older helper warns
-  against when combined with `usage=`.
+  below its budget — the spend is deducted once in the limit and again inside
+  the counter.
 - **The counter lives in a module-private `WeakKeyDictionary` keyed on the
   session**, not on `ContractSession` — `RunUsage` is a Pydantic AI type and
   `core/` stays framework-agnostic. Weak keys because the caller owns session
@@ -339,8 +340,8 @@ Three details carry the design:
 - **The tool wrapper picks its scope by identity**, not a flag: if `ctx.usage`
   *is* the counter registered for this session it accrues under one constant
   key, otherwise it falls back to `run_id`. So a caller who ignores the helper,
-  or passes its `usage_limits` without its `usage`, gets the older bounded
-  behaviour rather than a corrupted tally. Getting a boolean wrong is not a
+  or passes its `usage_limits` without its `usage`, gets plain per-run
+  scoping rather than a corrupted tally. Getting a boolean wrong is not a
   failure mode because there is no boolean. Treating a carried counter as
   per-run would inflate the session's tally and block runs still within budget —
   measured at 900 recorded against 600 truly spent, before the identity check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.37.0"
+version = "0.38.0"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/__init__.py
+++ b/src/agentic_data_contracts/__init__.py
@@ -45,14 +45,12 @@ try:
         contract_run_kwargs,
         create_pydantic_ai_tools,
         create_pydantic_ai_toolset,
-        usage_limits_from_contract,
     )
 except ImportError:  # pragma: no cover — exercised only without the extra
     ContractDeps = None  # ty: ignore[invalid-assignment]
     contract_run_kwargs = None  # ty: ignore[invalid-assignment]
     create_pydantic_ai_tools = None  # ty: ignore[invalid-assignment]
     create_pydantic_ai_toolset = None  # ty: ignore[invalid-assignment]
-    usage_limits_from_contract = None  # ty: ignore[invalid-assignment]
 
 __all__ = [
     "ClaudePromptRenderer",
@@ -80,5 +78,4 @@ __all__ = [
     "create_sdk_mcp_server",
     "create_tools",
     "resolve_principal",
-    "usage_limits_from_contract",
 ]

--- a/src/agentic_data_contracts/tools/pydantic_ai.py
+++ b/src/agentic_data_contracts/tools/pydantic_ai.py
@@ -335,6 +335,14 @@ def contract_run_kwargs(
     fed from outside the run — so keep that handler alongside
     ``pydantic_ai.exceptions.UsageLimitExceeded``.
 
+    ``contract`` supplies the budget and ``session`` supplies both the spend
+    and the counter, so pass the session built for *that* contract. A
+    mismatched pair enforces one contract's ceiling against another's usage
+    **and** writes the reconciled total into the wrong session — this function
+    does not only read the session, it feeds it. Deliberately not asserted:
+    ``ContractSession`` holds its contract, but comparing identity would reject
+    the legitimate case of an equivalent contract reloaded from YAML.
+
     **Adopt it from the start of a session.** The carried counter begins at
     zero and knows nothing of spend the session recorded before the first call
     — from a plain ``agent.run`` without these kwargs, from another adapter

--- a/src/agentic_data_contracts/tools/pydantic_ai.py
+++ b/src/agentic_data_contracts/tools/pydantic_ai.py
@@ -226,7 +226,8 @@ def _usage_scope(ctx: RunContext[Any], session: ContractSession) -> str | None:
     - **Carried** (``contract_run_kwargs``): ``ctx.usage`` *is* the
       ``RunUsage`` registered for this session, spanning every turn. One
       constant key, so the running total accrues once.
-    - **Per run** (the default, and ``usage_limits_from_contract``):
+    - **Per run** (the default, when the run was not given a carried
+      counter):
       ``ctx.usage`` restarts at zero each ``agent.run()``, so it is keyed by
       ``run_id`` and each run contributes its own total.
 
@@ -254,8 +255,8 @@ def contract_run_kwargs(
 ) -> dict[str, Any]:
     """Both halves of exact ``token_budget`` enforcement, for ``agent.run()``.
 
-    Supersedes :func:`usage_limits_from_contract`, whose spend grows linearly
-    with the number of turns rather than settling at the declared ceiling::
+    Passed to ``agent.run()``, this is what makes a declared ``token_budget``
+    bind on every model request rather than only when a tool is about to run::
 
         session = ContractSession(contract)          # one per user
         tools = create_pydantic_ai_tools(contract, adapter=adapter,
@@ -267,21 +268,22 @@ def contract_run_kwargs(
     correct together, which is why they are returned together rather than as
     two functions a caller could half-adopt.
 
-    **Why this is exact and the other is not.** ``usage_limits_from_contract``
-    subtracts ``session.tokens_used``, and the session is fed only from inside
-    the tool wrapper — so every model request after a run's last tool call, the
-    final answer included, goes unobserved and the shortfall compounds. Here the
-    same ``RunUsage`` is carried across every ``agent.run()`` for the session, so
-    Pydantic AI's own counter sees *every* request, and the tool wrapper reads
-    that one running total. Nothing is missed, so nothing has to be estimated.
+    **Why the counter is carried.** ``ContractSession`` is fed only from inside
+    the tool wrapper, so on its own it never sees a model request that happens
+    after a run's last tool call — the final answer most of all. Deriving a
+    per-run allowance from that tally under-counts, and the shortfall compounds
+    every turn. Carrying one ``RunUsage`` across every ``agent.run()`` for the
+    session means Pydantic AI's own counter sees *every* request and the tool
+    wrapper reads one running total. Nothing is missed, so nothing has to be
+    estimated.
 
     Two consequences follow, both measured on an agent spending 100 tokens per
     request against a 500-token budget:
 
     - **True spend settles instead of growing.** 600 against a 500-token
-      budget and *flat* however many turns run, where the superseded helper is
-      linear in turns: 1100 at 6, 1700 at 12, 2500 at 20. Flat-versus-linear is
-      the real difference; any single pair of numbers understates it.
+      budget, and *flat* however many turns run — where deriving the allowance
+      from the session's own tally is linear in turns (1100 at 6, 1700 at 12,
+      2500 at 20, measured before this existed).
     - **A refused turn costs nothing.** With the whole history in the counter,
       ``check_before_request`` refuses *before* issuing a request. The bounded
       helper cannot do this: its per-run counter starts at zero, so every
@@ -289,18 +291,44 @@ def contract_run_kwargs(
 
     The limit is **flat** (``total_tokens_limit=token_budget``), not the
     remainder. Subtracting would take the spend off twice — once in the limit
-    and once inside the carried counter — and lock the run out below its budget.
-    That is exactly why ``usage_limits_from_contract``'s docstring says not to
-    combine it with ``agent.run(usage=...)``.
+    and once inside the carried counter — and lock the run out below its own
+    budget.
 
-    Still call it **per run**. The counter is stable, but the ``UsageLimits`` is
-    rebuilt each time so a contract reloaded mid-conversation takes effect —
-    and hoisting it is no longer a correctness bug the way it was when the
-    limit carried a snapshot of spend.
+    Still call it **per run**. The counter is stable, but the ``UsageLimits``
+    is rebuilt each time so a contract reloaded mid-conversation takes
+    effect.
 
     A contract with no ``token_budget`` gets a carried counter and no token
     ceiling: usage is then tracked honestly for ``remaining()`` without
-    inventing a limit nothing declared.
+    inventing a limit nothing declared. An exhausted one yields
+    ``total_tokens_limit=0``; Pydantic AI's pre-request check compares
+    ``total_tokens > limit``, so a run whose counter is exactly at the ceiling
+    still issues one request before the post-request check aborts it.
+
+    What is deliberately **not** mapped:
+
+    - **``max_retries`` is NOT mapped onto ``request_limit``.** They count
+      different things — ``max_retries`` counts *blocked query attempts* here
+      (``record_retry()`` fires on a validation block), while ``request_limit``
+      counts *model requests*. A contract saying ``max_retries: 3`` means
+      "three bad queries and you are done", not "three LLM calls". Conflating
+      them would silently change what an existing contract means.
+      ``request_limit`` is left at Pydantic AI's own default, which is its
+      runaway guard and not ours to reinterpret.
+    - **``cost_limit_usd`` and ``max_duration_seconds``** have no
+      ``UsageLimits`` equivalent and stay session-side.
+
+    To add limits this contract does not express, copy the result::
+
+        kwargs = contract_run_kwargs(dc, session)
+        kwargs["usage_limits"] = dataclasses.replace(
+            kwargs["usage_limits"], tool_calls_limit=5
+        )
+
+    Pydantic AI only. LangChain has no per-request ceiling to map onto, and the
+    Claude Agent SDK path cannot observe usage at all — so this lives here, in
+    a module that only imports under the ``[pydantic-ai]`` extra, rather than
+    anywhere that would imply cross-framework coverage it does not have.
 
     ``ContractSessionLimitError`` remains reachable — the session still holds
     ``max_retries``, ``cost_limit_usd`` and ``max_duration_seconds``, and can be
@@ -342,135 +370,6 @@ def contract_run_kwargs(
     budget = resources.token_budget if resources is not None else None
     limits = UsageLimits() if budget is None else UsageLimits(total_tokens_limit=budget)
     return {"usage": usage, "usage_limits": limits}
-
-
-def usage_limits_from_contract(
-    contract: DataContract, session: ContractSession
-) -> UsageLimits:
-    """Translate a contract's ``token_budget`` into Pydantic AI ``UsageLimits``.
-
-    **Superseded by :func:`contract_run_kwargs`.** The ceiling here is not a
-    ceiling: spend grows *linearly with the number of turns* — measured at
-    2.2x the budget by 6 turns, 3.4x by 12, 5.0x by 20 — because each run is
-    granted a remainder computed from a tally that misses whatever the previous
-    run spent after its last tool call. ``contract_run_kwargs`` is flat at 1.2x
-    no matter how many turns run, and makes a refused turn cost nothing. Prefer
-    it. This remains supported and correct for what it claims — it needs
-    nothing but the limit, so it still suits a caller who cannot carry a
-    counter across turns.
-
-    Closes the window that in-tool enforcement cannot::
-
-        await agent.run(
-            prompt,
-            deps=ContractDeps(session=session),
-            usage_limits=usage_limits_from_contract(contract, session),
-        )
-
-    ``ContractSession.check_limits()`` runs *pre-tool-call*, so a breach stops
-    the next tool call — and an agent that burns its budget without calling
-    tools is never interrupted at all. ``UsageLimits`` is checked by Pydantic
-    AI on every model request, no tool call required, which closes that hole
-    **within a run**.
-
-    **The ``session`` argument is required, and is the whole point.**
-    ``total_tokens_limit`` is checked against ``RunUsage`` — usage for *one*
-    ``agent.run()`` call — while a contract's ``token_budget`` is a ceiling for
-    the user across every turn (:class:`ContractDeps` instructs callers to
-    reuse one session so limits accumulate). Passing the raw budget would
-    therefore grant it afresh on each turn: a 50,000-token contract would
-    authorise 50,000 *per turn*, so ten turns spend 500,000 under a contract
-    that says 50,000 — declared-but-unenforced, the failure this library exists
-    to prevent. Limiting each run to what the session has *left* bounds the
-    total instead.
-
-    Call it **per run**, not once at wiring time: the value is a snapshot of
-    remaining budget, and a stale one re-grants spend that already happened.
-
-    **This bounds the budget; it does not enforce it exactly.** The number
-    subtracted is ``session.tokens_used``, and the session is fed only from
-    inside the tool wrapper — so every model request *after a run's last tool
-    call*, including the final answer generation (typically the largest
-    context), is never observed. Each run is therefore granted more than the
-    true remainder, and the shortfall compounds per turn. Measured on a
-    two-request-per-turn agent with a 500-token budget, real spend reached ~2x
-    the ceiling *by the first refusal* — and that factor is not a constant, it
-    tracks how often the agent calls tools (~1.4x for a three-tool-call turn).
-    An agent that calls **no** tools is stopped within a run but remains
-    unbounded across them, since the session never accrues at all: 12 turns of
-    a 500-token budget spent 1200 with zero refusals. All of which is a large
-    improvement on the unbounded behaviour without this helper, and is not the
-    identity a quick read might assume. Issue #56 carries the design that would
-    make it exact (carry one ``RunUsage`` across turns via
-    ``agent.run(usage=...)``); it needs its own pass, because that counter is
-    global while ``observe_tokens`` scopes per ``run_id`` and would
-    double-count it today.
-
-    Three consequences of wiring this, none of them obvious:
-
-    - **Catch ``pydantic_ai.exceptions.UsageLimitExceeded`` as well as**
-      :class:`ContractSessionLimitError` — not instead of it. The framework
-      usually stops the run first, because a tool can only execute on a
-      response that already passed ``check_tokens``. But the contract-side
-      error still fires whenever the session is fed from outside the run — a
-      session shared with another adapter, or a direct ``observe_tokens()``
-      call — on either ``apply_middleware`` value. Dropping the existing
-      handler would leave those unhandled.
-    - **The session's token tally freezes** once the framework starts refusing
-      runs, since no further tools execute to feed it. ``remaining()`` will sit
-      at a stale figure while each refused turn still costs one billed model
-      request, so cumulative spend keeps climbing past that ~2x.
-    - **Do not combine with ``agent.run(usage=...)``.** A carried counter is
-      subtracted twice — once here, once inside the counter — and the run locks
-      out permanently below the declared budget.
-
-    Concurrent runs sharing one session each snapshot the same ``tokens_used``
-    and are each granted the full remainder. Correct for sequential turns,
-    which is what :class:`ContractDeps` describes; worth knowing if you fan out.
-
-    ``contract`` supplies the budget and ``session`` supplies the spend, so
-    pass the session built for *that* contract — a mismatched pair silently
-    enforces one contract's ceiling against another's usage. Not asserted:
-    ``ContractSession`` holds its contract, but comparing identity would reject
-    the legitimate case of an equivalent contract reloaded from YAML.
-
-    To add limits this contract does not express, copy the result::
-
-        dataclasses.replace(usage_limits_from_contract(dc, s), tool_calls_limit=5)
-
-    What is deliberately not mapped:
-
-    - **``max_retries`` is NOT mapped onto ``request_limit``.** They count
-      different things — ``max_retries`` counts *blocked query attempts* here
-      (``record_retry()`` fires on a validation block), while ``request_limit``
-      counts *model requests*. A contract saying ``max_retries: 3`` means
-      "three bad queries and you are done", not "three LLM calls". Conflating
-      them would silently change what an existing contract means.
-      ``request_limit`` is left at Pydantic AI's own default, which is its
-      runaway guard and not ours to reinterpret.
-    - **``cost_limit_usd`` and ``max_duration_seconds``** have no
-      ``UsageLimits`` equivalent and stay session-side.
-
-    Returns ``UsageLimits`` with ``total_tokens_limit`` unset when the contract
-    declares no ``token_budget`` — inventing a ceiling nothing declared would be
-    the mirror image of failing to enforce one that was.
-
-    An exhausted budget yields ``total_tokens_limit=0``. Pydantic AI's
-    pre-request check compares ``total_tokens > limit`` against a run that has
-    not started, so ``0 > 0`` is false and one model request still goes out
-    before the post-request check aborts the run — a per-refused-turn cost, not
-    a one-off.
-
-    Pydantic AI only. LangChain has no per-request ceiling to map onto, and the
-    Claude Agent SDK path cannot observe usage at all — so this lives here, in
-    a module that only imports under the ``[pydantic-ai]`` extra, rather than
-    anywhere that would imply cross-framework coverage it does not have.
-    """
-    resources = contract.schema.resources
-    budget = resources.token_budget if resources is not None else None
-    if budget is None:
-        return UsageLimits()
-    return UsageLimits(total_tokens_limit=max(0, budget - session.tokens_used))
 
 
 @dataclass

--- a/tests/test_tools/test_pydantic_ai.py
+++ b/tests/test_tools/test_pydantic_ai.py
@@ -34,7 +34,6 @@ from agentic_data_contracts.tools.pydantic_ai import (  # noqa: E402
     contract_run_kwargs,
     create_pydantic_ai_tools,
     create_pydantic_ai_toolset,
-    usage_limits_from_contract,
 )
 
 # ─── helpers ──────────────────────────────────────────────────────────────────
@@ -552,14 +551,14 @@ def test_toolset_rejects_contract_deps_with_no_session(
 
 def test_top_level_import_resolves_when_extra_installed() -> None:
     from agentic_data_contracts import ContractDeps as _CD
+    from agentic_data_contracts import contract_run_kwargs as _crk
     from agentic_data_contracts import create_pydantic_ai_tools as _ct
     from agentic_data_contracts import create_pydantic_ai_toolset as _cts
-    from agentic_data_contracts import usage_limits_from_contract as _ul
 
+    assert _crk is not None
     assert _ct is not None
     assert _cts is not None
     assert _CD is not None
-    assert _ul is not None
 
 
 # ─── token budget (v0.34.0) ───────────────────────────────────────────────────
@@ -675,7 +674,7 @@ async def test_exhausted_token_budget_is_terminal(adapter: DuckDBAdapter) -> Non
         )
 
 
-# ─── usage_limits_from_contract (v0.36.0) ─────────────────────────────────────
+# ─── shared budget fixture ───────────────────────────────────────────────────
 
 
 def _budgeted_contract(budget: int | None = 50_000) -> DataContract:
@@ -696,222 +695,7 @@ def _budgeted_contract(budget: int | None = 50_000) -> DataContract:
     )
 
 
-def test_usage_limits_maps_token_budget() -> None:
-    session = ContractSession(_budgeted_contract())
-    assert (
-        usage_limits_from_contract(_budgeted_contract(), session).total_tokens_limit
-        == 50_000
-    )
-
-
-def test_usage_limits_subtracts_what_the_session_already_spent() -> None:
-    """The whole reason the helper takes a session.
-
-    ``UsageLimits`` is checked against ``RunUsage`` — per ``agent.run()`` call —
-    while a ``ContractSession``'s budget is per *user across every turn*
-    (``ContractDeps`` says to reuse one session so limits accumulate). Mapping
-    the raw budget would therefore grant it afresh on every turn: a 50k
-    contract would authorise 50k *per turn*, which is not what it declares.
-    """
-    contract = _budgeted_contract()
-    session = ContractSession(contract)
-    session.observe_tokens(30_000, scope="turn-1")
-
-    limits = usage_limits_from_contract(contract, session)
-    assert limits.total_tokens_limit == 20_000
-
-
-def test_usage_limits_floor_at_zero_never_goes_negative() -> None:
-    # A negative limit would be nonsense to pydantic-ai; an exhausted budget
-    # must clamp to 0, which aborts the run on its first usage check.
-    contract = _budgeted_contract()
-    session = ContractSession(contract)
-    session.observe_tokens(70_000, scope="over")
-
-    assert usage_limits_from_contract(contract, session).total_tokens_limit == 0
-
-
-def test_usage_limits_distinguishes_a_zero_budget_from_no_budget() -> None:
-    """``token_budget: 0`` is a declaration, not an absence.
-
-    Zero means "spend nothing"; absent means "no ceiling". Collapsing them
-    would turn the strictest possible budget into no budget at all, which is
-    the same declared-but-unenforced shape this helper exists to avoid.
-    """
-    contract = _budgeted_contract(0)
-    assert (
-        usage_limits_from_contract(
-            contract, ContractSession(contract)
-        ).total_tokens_limit
-        == 0
-    )
-
-
-def test_usage_limits_leaves_token_limit_unset_without_a_budget() -> None:
-    # No declared budget means no token ceiling to translate. Inventing one
-    # would be the mirror image of the declared-but-unenforced bug.
-    contract = _budgeted_contract(budget=None)
-    limits = usage_limits_from_contract(contract, ContractSession(contract))
-    assert limits.total_tokens_limit is None
-
-
-def test_usage_limits_does_not_map_max_retries_onto_request_limit() -> None:
-    """The trap this helper exists partly to prevent.
-
-    ``max_retries`` counts *blocked query attempts* in this library;
-    ``request_limit`` counts *model requests*. A contract saying
-    ``max_retries: 3`` means "three bad queries", not "three LLM calls" —
-    mapping one onto the other silently changes what an existing contract
-    means. ``request_limit`` is therefore left at pydantic-ai's own default.
-    """
-    contract = DataContract(
-        DataContractSchema(
-            name="retries",
-            semantic=SemanticConfig(
-                allowed_tables=[
-                    AllowedTable.model_validate(
-                        {"schema": "analytics", "tables": ["orders"]}
-                    ),
-                ],
-            ),
-            resources=ResourceConfig(max_retries=3, token_budget=50_000),
-        )
-    )
-    limits = usage_limits_from_contract(contract, ContractSession(contract))
-    assert limits.request_limit == UsageLimits().request_limit
-    assert limits.request_limit != 3
-
-
-@pytest.mark.asyncio
-async def test_multi_turn_spend_is_bounded_but_not_exact(
-    adapter: DuckDBAdapter,
-) -> None:
-    """The honest property, measured through the wiring users actually write.
-
-    An earlier version of this test asserted that spending exactly what the
-    helper allows leaves the session exactly at its budget. That was arithmetic
-    dressed up as a guarantee: it *stipulated* the session observes the full
-    run, which is the one thing that does not happen. The session is fed only
-    inside the tool wrapper, so every model request after a run's last tool
-    call — including answer generation — goes unobserved, and the subtraction
-    compounds that shortfall each turn.
-
-    So the real property is a bound, not an identity: the framework does stop
-    the agent, at a multiple of the budget rather than at it.
-
-    The regression this guards is the unsubtracted mapping from issue #53. Note
-    *how* that one dies here — not by running away until the loop gives up, but
-    by the session's own in-tool enforcement raising ``ContractSessionLimitError``
-    on the third turn, because the per-run limit stops constraining anything and
-    the tools hit the ceiling first. That is caught explicitly below rather than
-    left to propagate, so the failure names the cause instead of surfacing as an
-    unrelated error.
-    """
-    from pydantic_ai.exceptions import UsageLimitExceeded
-    from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
-    from pydantic_ai.models.function import AgentInfo, FunctionModel
-    from pydantic_ai.usage import RequestUsage
-
-    budget = 500
-    per_request = 100
-    contract = _budgeted_contract(budget)
-    spent = 0
-
-    def _model(messages: list[Any], info: AgentInfo) -> ModelResponse:
-        # One tool call, then a text answer — the shape that leaves an
-        # unobserved tail on every turn.
-        nonlocal spent
-        spent += per_request
-        usage = RequestUsage(
-            input_tokens=per_request // 2, output_tokens=per_request // 2
-        )
-        called = any(
-            getattr(part, "part_kind", "") == "tool-return"
-            for message in messages
-            for part in getattr(message, "parts", [])
-        )
-        if called:
-            return ModelResponse(parts=[TextPart("done")], usage=usage)
-        return ModelResponse(
-            parts=[
-                ToolCallPart(
-                    "describe_table", {"schema": "analytics", "table": "orders"}
-                )
-            ],
-            usage=usage,
-        )
-
-    session = ContractSession(contract)
-    agent = Agent(
-        FunctionModel(_model),
-        tools=create_pydantic_ai_tools(contract, adapter=adapter, session=session),
-    )
-
-    stopped = False
-    for turn in range(12):
-        try:
-            await agent.run(
-                "go", usage_limits=usage_limits_from_contract(contract, session)
-            )
-        except UsageLimitExceeded:
-            stopped = True
-            break
-        except ContractSessionLimitError as e:  # pragma: no cover — regression guard
-            pytest.fail(
-                f"turn {turn}: the session enforcer fired before the framework"
-                f" did, which means the per-run limit stopped constraining the"
-                f" run — the unsubtracted mapping from issue #53. ({e})"
-            )
-
-    assert stopped, "the framework must eventually refuse the run"
-    # The framework fires while spend is still a small multiple of the budget.
-    # Loose because the overshoot tracks the tool-call-to-request ratio, not a
-    # constant — see the module's known limitations.
-    assert spent <= budget * 3
-
-
-@pytest.mark.asyncio
-async def test_limits_actually_stop_a_real_run() -> None:
-    """The load-bearing test: does the helper's output bind through agent.run()?
-
-    Every other test in this section checks arithmetic on the returned object,
-    and all of them would still pass if ``UsageLimits`` were ignored entirely —
-    which is the whole feature. This drives a real ``Agent.run`` with a budget
-    the session has all but spent, and asserts the run is refused.
-
-    That refusal arrives from Pydantic AI on a *model request*, with no tool
-    call needed — which is precisely the window ``check_limits()`` cannot
-    close, since it only ever runs when a tool is about to be invoked.
-    """
-    from pydantic_ai.exceptions import UsageLimitExceeded
-
-    contract = _budgeted_contract()
-    session = ContractSession(contract)
-    session.observe_tokens(49_999, scope="earlier-turns")
-
-    agent = Agent(TestModel())
-    with pytest.raises(UsageLimitExceeded):
-        await agent.run(
-            "anything",
-            usage_limits=usage_limits_from_contract(contract, session),
-        )
-
-
-@pytest.mark.asyncio
-async def test_a_fresh_budget_does_not_stop_a_run() -> None:
-    # The other half: the limit must not be so tight that it refuses everything.
-    # Without this, the test above would pass on a helper that always returns 0.
-    contract = _budgeted_contract()
-    session = ContractSession(contract)
-
-    result = await Agent(TestModel()).run(
-        "anything",
-        usage_limits=usage_limits_from_contract(contract, session),
-    )
-    assert result.output
-
-
-# ─── contract_run_kwargs — exact enforcement (v0.37.0) ────────────────────────
+# ─── contract_run_kwargs — exact token_budget accounting ──────────────────────
 
 
 def _tool_calling_model(spend: list[int]) -> Any:
@@ -1094,9 +878,7 @@ async def test_ignoring_the_helper_degrades_rather_than_corrupts(
 
     for _ in range(6):
         try:
-            await agent.run(
-                "go", usage_limits=usage_limits_from_contract(contract, session)
-            )
+            await agent.run("go", usage_limits=UsageLimits(total_tokens_limit=500))
         except (UsageLimitExceeded, ContractSessionLimitError):
             break
 
@@ -1169,3 +951,60 @@ def test_contract_session_stays_usable_as_a_weak_key() -> None:
     # budgets and must never share a counter.
     assert ContractSession.__hash__ is object.__hash__
     assert ContractSession(contract) != session
+
+
+def test_run_kwargs_does_not_map_max_retries_onto_request_limit() -> None:
+    """The mapping trap, kept alive through the removal of the older helper.
+
+    ``max_retries`` counts *blocked query attempts* in this library;
+    ``request_limit`` counts *model requests*. A contract saying
+    ``max_retries: 3`` means "three bad queries", not "three LLM calls", so
+    mapping one onto the other would silently change what an existing contract
+    means. ``request_limit`` is left at Pydantic AI's own default — its runaway
+    guard, not ours to reinterpret.
+
+    This test moved here when ``usage_limits_from_contract`` was deleted: the
+    caveat is a property of translating contracts to ``UsageLimits`` at all,
+    not of the function that happened to do it first.
+    """
+    contract = DataContract(
+        DataContractSchema(
+            name="retries",
+            semantic=SemanticConfig(
+                allowed_tables=[
+                    AllowedTable.model_validate(
+                        {"schema": "analytics", "tables": ["orders"]}
+                    ),
+                ],
+            ),
+            resources=ResourceConfig(max_retries=3, token_budget=50_000),
+        )
+    )
+    limits = contract_run_kwargs(contract, ContractSession(contract))["usage_limits"]
+
+    assert limits.request_limit == UsageLimits().request_limit
+    assert limits.request_limit != 3
+
+
+def test_run_kwargs_distinguishes_a_zero_budget_from_no_budget() -> None:
+    """``token_budget: 0`` is a declaration, not an absence.
+
+    Zero means "spend nothing"; absent means "no ceiling". Collapsing them
+    would turn the strictest possible budget into no budget at all — the
+    declared-but-unenforced shape this library exists to catch.
+    """
+    zero = _budgeted_contract(0)
+    absent = _budgeted_contract(None)
+
+    assert (
+        contract_run_kwargs(zero, ContractSession(zero))[
+            "usage_limits"
+        ].total_tokens_limit
+        == 0
+    )
+    assert (
+        contract_run_kwargs(absent, ContractSession(absent))[
+            "usage_limits"
+        ].total_tokens_limit
+        is None
+    )

--- a/tests/test_tools/test_pydantic_ai.py
+++ b/tests/test_tools/test_pydantic_ai.py
@@ -815,9 +815,10 @@ async def test_carried_counter_enforces_the_budget_exactly(
 
     # True spend overshoots only by the requests already in flight when the
     # ceiling was crossed, and then STOPS -- running more turns does not spend
-    # more. The superseded helper grows linearly instead: 2.6x over these same
-    # 8 turns, 3.4x over 12, 5x over 20. Flat-versus-linear is the property;
-    # the tolerance below just pins the one-run overshoot.
+    # more. Deriving each run's allowance from the session's own tally instead
+    # grows linearly: 2.6x over these same 8 turns, 3.4x over 12, 5x over 20.
+    # Flat-versus-linear is the property; the tolerance below just pins the
+    # one-run overshoot.
     assert sum(spend) <= budget + 200
 
 
@@ -863,8 +864,9 @@ async def test_ignoring_the_helper_degrades_rather_than_corrupts(
 
     The wrapper switches to the stable scope only when ``ctx.usage`` *is* the
     counter registered for this session. A caller who passes a limit but no
-    carried counter therefore gets v0.36.0's per-run scoping — bounded, not
-    double-counted, which is the failure this design must not reintroduce.
+    carried counter therefore gets plain per-run scoping, which under-counts —
+    never the double-count that would block a run still within budget, which is
+    the failure this design must not reintroduce.
     """
     from pydantic_ai.exceptions import UsageLimitExceeded
 
@@ -882,8 +884,8 @@ async def test_ignoring_the_helper_degrades_rather_than_corrupts(
         except (UsageLimitExceeded, ContractSessionLimitError):
             break
 
-    # Under-counts (the documented v0.36.0 bound); never over-counts, which is
-    # what would stop a run that is still within budget.
+    # Under-counts; never over-counts, which is what would stop a run that is
+    # still within budget.
     assert session.tokens_used <= sum(spend)
 
 
@@ -954,7 +956,7 @@ def test_contract_session_stays_usable_as_a_weak_key() -> None:
 
 
 def test_run_kwargs_does_not_map_max_retries_onto_request_limit() -> None:
-    """The mapping trap, kept alive through the removal of the older helper.
+    """The mapping trap, kept alive through the removal of its first home.
 
     ``max_retries`` counts *blocked query attempts* in this library;
     ``request_limit`` counts *model requests*. A contract saying

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Removes `usage_limits_from_contract`, added in v0.36.0 and superseded by `contract_run_kwargs` in v0.37.0 — **28 minutes later**, by release timestamp.

## Why remove rather than keep it superseded

The justification for keeping it was that it *"suits a caller who cannot carry a counter across turns"*. That describes an **empty set**:

| API | `usage_limits=` | `usage=` |
|---|---|---|
| `run`, `run_sync`, `run_stream`, `run_stream_events`, `iter` | ✅ | ✅ |

Every Pydantic AI run API that accepts the limit also accepts the counter. There is no call path where one can be passed and the other cannot — so there was never a caller the old helper served and the new one does not. I wrote that sentence to justify keeping the function; it does not describe anyone.

Meanwhile the two behave differently in a way no reader can see from the signatures:

| turns | `usage_limits_from_contract` | `contract_run_kwargs` |
|---|---|---|
| 6 | 2.2× budget | **1.2×** |
| 12 | 3.4× | **1.2×** |
| 20 | 5.0× | **1.2×** |

Keeping both meant the README offered **two ways to do one thing, where the simpler-looking one silently under-enforces**. That is the failure class v0.32.0–v0.37.0 have been systematically removing, reintroduced as a menu choice.

## Why not a deprecation cycle

A deprecation window's value scales with adoption, and a symbol that was the latest release for 28 minutes has none to speak of. `DeprecationWarning` is also hidden by default in application code. This is a `0.x` project at Beta status, where SemVer permits a breaking change in a minor bump.

## What was migrated rather than deleted with it

The deleted docstring was the **only** home for several governance facts. These now live on `contract_run_kwargs`, with their guarding tests rewritten against it:

- **`max_retries` must not map onto `request_limit`** — ours counts *blocked query attempts*, theirs counts *model requests*; conflating them silently redefines existing contracts. This is a property of translating contracts into `UsageLimits` at all, not of whichever function does it.
- `cost_limit_usd` / `max_duration_seconds` have no equivalent and stay session-side.
- The zero-versus-absent budget distinction (`token_budget: 0` means "spend nothing", absent means "no ceiling").
- The `dataclasses.replace` path for adding limits the contract does not express.

Also added `contract_run_kwargs` to the top-level import test, which had never covered it.

## Migration

One line, and it strictly improves enforcement:

```diff
- usage_limits=usage_limits_from_contract(dc, session),
+ **contract_run_kwargs(dc, session),
```

## Compatibility

**Breaking** for anyone who adopted the helper during the 28 minutes it was current. `from agentic_data_contracts import usage_limits_from_contract` now raises `ImportError`.

906 tests passing; floors verified at pydantic-ai-slim 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
