### PR TITLE
fix: expected_extras survives model_dump, exclusion moves to the digest (v0.41.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.41.1] - 2026-08-11
+
+### Fixed
+
+- **`semantic.source.expected_extras` no longer disappears from an ordinary `model_dump()`.** v0.41.0 kept the field out of `contract_digest` with `Field(exclude=True)`, which was too blunt: a field-level exclusion applies to *every* serialization, so a tool that round-tripped a contract through `model_dump()` locally and revalidated it silently lost the declaration — and got back the warning it had just silenced. The empty-list form (strict mode) collapsed to `None` on the same path, quietly downgrading strict to warn-and-carry.
+
+  The exclusion now lives where it belongs, at the one call site that computes the content address (`_CANONICAL_EXCLUDE` in `contract_canonical_bytes`), rather than on the field. Published bytes are unchanged in every respect: `contract_digest` for a contract with no extras is still `sha256:898c842e…`, and `expected_extras` still never appears in `contract_canonical_bytes` in any form. The rule the field-level exclusion was reaching for — a lint policy about *reading* the source should not move the digest — is intact; it just no longer costs correctness everywhere else.
+
+  Found by the whole-branch review of #62 and documented as a known limitation at the time.
+
 ## [0.41.0] - 2026-08-11
 
 Closes #60, whose three defects share one shape: **the library delivered less

--- a/README.md
+++ b/README.md
@@ -993,10 +993,9 @@ right way round: the declaration is a lint on *your* authoring, and buying the
 consumer's silence with a digest change would invalidate every attestation
 pinned to the contract.
 
-The exclusion is field-level, so the same applies to any `model_dump()` — a tool
-that round-trips a contract through `model_dump()` locally and reloads it drops
-the declaration too, and the warning comes back. Re-read the contract from YAML
-rather than from a dump if you need the setting to survive.
+The exclusion is scoped to the content-addressed bytes, not to the field, so an
+ordinary `model_dump()` still carries it and a local round trip keeps your
+declaration. Only what gets published drops it.
 
 Nothing renders unless you name it in `extra_sections`, so a section kept for
 internal bookkeeping never reaches a prompt. Naming a section the source does not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.41.0"
+version = "0.41.1"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/ard.py
+++ b/src/agentic_data_contracts/ard.py
@@ -39,6 +39,18 @@ MCP_SERVER_CARD_MEDIA_TYPE = "application/mcp-server-card+json"
 #: registered well-known value.
 DATA_CONTRACT_ATTESTATION_TYPE = "data-contract"
 
+#: Fields kept out of the content-addressed bytes. ``semantic.source
+#: .expected_extras`` is a load-time lint policy — it does not change what the
+#: agent sees — so serializing it would move every published digest for a
+#: setting no consumer of the bytes can act on.
+#:
+#: Excluded here rather than with ``Field(exclude=True)`` on the model: a
+#: field-level exclusion applies to *every* ``model_dump()``, which silently
+#: drops the declaration from an ordinary local round trip. The exclusion
+#: belongs to the digest, so it lives with the digest. Paths use pydantic
+#: **field** names, not aliases, even under ``by_alias=True``.
+_CANONICAL_EXCLUDE = {"semantic": {"source": {"expected_extras"}}}
+
 
 def contract_canonical_bytes(contract: DataContract) -> bytes:
     """The frozen, canonical JSON bytes of a contract — the portable artifact you
@@ -53,7 +65,9 @@ def contract_canonical_bytes(contract: DataContract) -> bytes:
     # by_alias so the published, content-addressed bytes use the documented YAML
     # keys (e.g. ``schema``), not pydantic field names (``schema_``) — a non-library
     # consumer reads the same shape the contract was authored in.
-    payload = contract.schema.model_dump(mode="json", by_alias=True)
+    payload = contract.schema.model_dump(
+        mode="json", by_alias=True, exclude=_CANONICAL_EXCLUDE
+    )
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
 
 

--- a/src/agentic_data_contracts/core/schema.py
+++ b/src/agentic_data_contracts/core/schema.py
@@ -30,13 +30,15 @@ class SemanticSource(BaseModel):
     # mode — makes any undeclared top-level key a load error. Ignored by the dbt
     # and cube loaders, which have no extras concept.
     #
-    # ``exclude=True`` is load-bearing: ``contract_canonical_bytes`` dumps this
-    # model with ``model_dump(mode="json", by_alias=True)`` to produce
-    # ``contract_digest``, so a serialized field — even as ``null`` — would move
-    # every existing digest and invalidate every published ARD attestation. This
-    # is a policy about *reading* the source, not part of what the agent sees, so
-    # it must not be digest-bearing.
-    expected_extras: list[str] | None = Field(default=None, exclude=True)
+    # Must not reach ``contract_digest``: a serialized field — even as ``null``
+    # — would move every existing digest and invalidate every published ARD
+    # attestation, and this is a policy about *reading* the source, not part of
+    # what the agent sees. That exclusion lives in ``contract_canonical_bytes``
+    # (``_CANONICAL_EXCLUDE``), NOT here as ``Field(exclude=True)``: a
+    # field-level exclusion applies to every ``model_dump()``, so a tool that
+    # round-trips a contract locally would silently lose the declaration and get
+    # back the warning it had silenced.
+    expected_extras: list[str] | None = None
 
     @model_validator(mode="after")
     def path_or_inline_required(self) -> Self:

--- a/tests/test_core/test_schema.py
+++ b/tests/test_core/test_schema.py
@@ -275,3 +275,53 @@ def test_required_filter_values_extra_field_rejected() -> None:
                 "typo_field": "oops",
             }
         )
+
+
+def test_expected_extras_survives_a_model_dump_round_trip() -> None:
+    """Excluded from the *digest*, not from serialization in general.
+
+    ``contract_canonical_bytes`` must not carry this field — see
+    ``test_expected_extras_is_not_digest_bearing`` in the ARD suite for the other
+    half of this decision. But excluding it at the *field* drops it from every
+    ``model_dump()``, so a tool that round-trips a contract locally loses the
+    declaration and the warning it silenced comes back. The exclusion belongs at
+    the one call site that computes the content address, not on the field.
+    """
+    raw = {
+        "version": "1.0",
+        "name": "extras-round-trip",
+        "semantic": {
+            "source": {
+                "type": "yaml",
+                "path": "./semantic.yml",
+                "expected_extras": ["column_hints", "join_paths"],
+            },
+            "allowed_tables": [{"schema": "analytics", "tables": ["orders"]}],
+        },
+    }
+    schema = DataContractSchema.model_validate(raw)
+    rebuilt = DataContractSchema.model_validate(schema.model_dump())
+
+    assert rebuilt.semantic.source is not None
+    assert rebuilt.semantic.source.expected_extras == ["column_hints", "join_paths"]
+
+
+def test_empty_expected_extras_survives_a_model_dump_round_trip() -> None:
+    """``[]`` is strict mode — a real value, distinct from an absent key.
+
+    A round trip that collapsed it to ``None`` would silently downgrade strict
+    mode to warn-and-carry, which is the failure this whole feature removes.
+    """
+    raw = {
+        "version": "1.0",
+        "name": "extras-strict",
+        "semantic": {
+            "source": {"type": "yaml", "path": "./s.yml", "expected_extras": []},
+            "allowed_tables": [{"schema": "analytics", "tables": ["orders"]}],
+        },
+    }
+    schema = DataContractSchema.model_validate(raw)
+    rebuilt = DataContractSchema.model_validate(schema.model_dump())
+
+    assert rebuilt.semantic.source is not None
+    assert rebuilt.semantic.source.expected_extras == []

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.41.0"
+version = "0.41.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Follow-up to #62, closing the known limitation its whole-branch review surfaced.

## The bug

v0.41.0 kept `semantic.source.expected_extras` out of `contract_digest` with `Field(exclude=True)`. That is **field-level**, so it fired on every `model_dump()` — not just the one that computes the content address. A tool that round-tripped a contract locally and revalidated it silently lost the declaration and got back the warning it had just silenced.

The empty-list form was worse: `expected_extras: []` is *strict mode*, a real value distinct from an absent key, and it collapsed to `None` on the same path — quietly downgrading strict to warn-and-carry.

## The fix

The exclusion moves from the field to the one call site that needs it:

```python
_CANONICAL_EXCLUDE = {"semantic": {"source": {"expected_extras"}}}
...
payload = contract.schema.model_dump(mode="json", by_alias=True, exclude=_CANONICAL_EXCLUDE)
```

The rule the field-level exclusion was reaching for is intact — a lint policy about *reading* the source must not move the digest — it just no longer costs correctness everywhere else.

## Published bytes are unchanged

Verified the new exclude is load-bearing rather than incidentally passing:

| | digest | `expected_extras` in bytes |
|---|---|---|
| with `_CANONICAL_EXCLUDE` | `sha256:898c842e…` (the pinned value) | absent |
| without it | `sha256:ef202423…` | present |

All three pre-existing guards pass untouched: `test_roundtrip_contract_digest_is_pinned`, `test_expected_extras_is_not_digest_bearing`, `test_expected_extras_is_absent_from_the_canonical_bytes`.

## Tests

Two new tests in `tests/test_core/test_schema.py`, written first and watched fail with `assert None == ['column_hints', 'join_paths']` and `assert None == []`:

- `test_expected_extras_survives_a_model_dump_round_trip`
- `test_empty_expected_extras_survives_a_model_dump_round_trip`

964 passing; all four prek hooks green; examples still exit 0. README corrected — the paragraph documenting this as a limitation is now wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
