### PR TITLE
docs: record why Pydantic AI run cancellation is not adopted, and test it

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -368,6 +368,38 @@ the SDK path cannot observe usage at all, so the helper lives in a module that
 imports only under the `[pydantic-ai]` extra rather than anywhere implying
 coverage it lacks.
 
+**Run cancellation is a third deliberate non-adoption (assessed 2026-08-16,
+against Pydantic AI 2.31).** Pydantic AI 2.26 added first-party cancellation —
+`AgentRun.cancel()`, `RunContext.cancel()`, `RunCancelled` — and a terminal
+budget breach looks like exactly the condition it was built for. It is not
+adopted, for three reasons:
+
+- **Framework neutrality is a stated property of this library.** A terminal
+  breach raises `ContractSessionLimitError` identically on the Agent SDK,
+  LangChain and Pydantic AI paths. Routing one adapter through a
+  framework-native mechanism would make governance behave differently depending
+  on which agent framework the caller happened to pick — the divergence this
+  library exists to remove.
+- **A governance stop is not a cancellation.** `RunCancelled` reads as *someone
+  asked to stop*; a breached budget is *policy refused*. A caller catching
+  `RunCancelled` to handle a user pressing Stop would silently swallow a limit
+  breach. Distinct meanings need distinct types.
+- **It would add a third path, not unify two.** A limit already trips on either
+  the tool side (`ContractSessionLimitError`) or the model side
+  (`UsageLimitExceeded`), and callers are told above to catch both. Cancellation
+  does not collapse that pair; it appends to it.
+
+The third reason assumes the exception escapes `agent.run()` at all, so that
+assumption is a test rather than a belief:
+`test_terminal_limit_error_escapes_agent_run` runs a breach through Pydantic
+AI's own tool-execution machinery and asserts `ContractSessionLimitError`
+propagates uncaught. Every other terminal-limit test invokes the tool function
+directly, proving only that *our* wrapper raises. Because
+`test-pydantic-ai-latest` runs this module against the newest release the floor
+allows, a future version that caught non-`ModelRetry` tool exceptions — turning
+a breached budget into a retry — would surface there rather than in a user's
+install. Revisit this decision if that job ever goes red on it.
+
 When `ai-agent-contracts` IS installed, enforcement is delegated to the formal framework via the bridge layer (see below).
 
 ## Validation Layer

--- a/tests/test_tools/test_pydantic_ai.py
+++ b/tests/test_tools/test_pydantic_ai.py
@@ -1010,3 +1010,33 @@ def test_run_kwargs_distinguishes_a_zero_budget_from_no_budget() -> None:
         ].total_tokens_limit
         is None
     )
+
+
+async def test_terminal_limit_error_escapes_agent_run(adapter: DuckDBAdapter) -> None:
+    """A terminal breach must propagate out of ``agent.run()`` uncaught.
+
+    Every other terminal-limit test in this file invokes the tool function
+    directly, which proves *our* wrapper raises. This one runs the exception
+    through Pydantic AI's own tool-execution machinery, which is the part we
+    do not own: if a future release ever caught non-``ModelRetry`` exceptions
+    from a tool and converted them into a retry or a run-level failure, a
+    breached contract budget would stop being terminal and no other test here
+    would notice.
+
+    That failure mode is why ``docs/architecture.md`` declines Pydantic AI's
+    first-party run cancellation for this path — the argument assumes the
+    exception escapes. This test is the assumption, written down.
+
+    Deliberately no ``usage_limits``: passing one lets ``UsageLimitExceeded``
+    fire on the model side first, which would pass the assertion below for the
+    wrong reason and hide a swallowed ``ContractSessionLimitError``.
+    """
+    contract = _budgeted_contract(1)
+    session = ContractSession(contract)
+    agent = Agent(
+        _tool_calling_model([]),
+        tools=create_pydantic_ai_tools(contract, adapter=adapter, session=session),
+    )
+
+    with pytest.raises(ContractSessionLimitError, match="token"):
+        await agent.run("go")


### PR DESCRIPTION
Assessed `pydantic-ai` **2.22 → 2.31** — the range v0.42.0's dependency upgrade crossed. Conclusion: **no code changes needed**. This PR records the one decision worth writing down, and closes the test gap that decision depends on.

## Assessment summary

| | |
|---|---|
| **Free win, already realised** | 2.29.0 renders parameter descriptions in tool signatures. All 16 tool params in `factory.py` already carry them, so grounding improved on upgrade with zero work. |
| **Not applicable** | Tool hiding/reveal (our tool set is uniform; `ContractDeps` already scopes by principal), realtime speech, new providers, AG-UI/Vercel, Temporal. |
| **Not a risk** | Compaction changes affect *message history*; the contract prompt is agent-level instructions, re-sent per request. Enforcement is query-time regardless. |
| **Security advisories** | All three GHSAs are in `Agent.to_web()` / `clai web`, which we never call. Floor deliberately left at `>=2.0.0` — raising it over a dev-UI issue in an unused path would break users pinned low for unrelated reasons. |

## The decision worth recording

2.26 added first-party cancellation (`AgentRun.cancel()`, `RunContext.cancel()`, `RunCancelled`), and a terminal budget breach looks exactly like what it was built for. Declined:

- **Framework neutrality is a stated property.** `ContractSessionLimitError` is raised identically on the Agent SDK, LangChain and Pydantic AI paths. Routing one through a framework-native mechanism would make governance behave differently depending on which framework the caller picked.
- **A governance stop is not a cancellation.** `RunCancelled` reads as *someone asked to stop*; a caller catching it to handle a user pressing Stop would silently swallow a limit breach.
- **It appends a third path** rather than unifying the existing two (tool-side `ContractSessionLimitError`, model-side `UsageLimitExceeded`).

## The gap this exposed

The third reason assumes the exception escapes `agent.run()` at all — and **nothing tested that**. Every existing terminal-limit test invokes the tool function directly, proving only that *our* wrapper raises. The one test that used `agent.run()` accepted either exception and asserted on token counts, so it would pass even if `ContractSessionLimitError` were swallowed.

`test_terminal_limit_error_escapes_agent_run` runs a breach through Pydantic AI's own tool-execution machinery and asserts it propagates uncaught.

**Verified it discriminates:** downgrading the breach to `ModelRetry` makes Pydantic AI retry and raise `UnexpectedModelBehavior` — the test fails. It isn't vacuous.

It lives in the module `test-pydantic-ai-latest` runs, so a future release that caught non-`ModelRetry` tool exceptions — turning a breached budget into a retry — surfaces in CI rather than in a user's install.

## Verification

1003 tests pass (+1); `prek run --all-files` clean. Also ran the `test-pydantic-ai-latest` job's exact invocation locally against the newest resolvable release — 42 passed.

Docs only plus one test, so no version bump.

> Stacked context: [#65](https://github.com/flyersworder/agentic-data-contracts/pull/65) is open separately and touches a different section of `architecture.md`; no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)