### PR TITLE
test: the pinned round-trip digest now covers metric serialization

### DIFF
--- a/tests/fixtures/relationships_checker.yml
+++ b/tests/fixtures/relationships_checker.yml
@@ -1,3 +1,41 @@
+# Relationship fixture for RelationshipChecker and the validator suites.
+#
+# It also backs tests/fixtures/roundtrip_contract.yml, whose digest is pinned by
+# test_roundtrip_contract_digest_is_pinned. That pin is the repo's broadest guard
+# against canonical-bytes drift, so the metrics below exist to put the *metric*
+# serialization path inside it: every optional field `_dump_metric` writes is
+# represented here, so making any of them unconditional moves the pin instead of
+# passing unnoticed. See #73 — before this, the pinned contract had no metrics at
+# all and could not see a single change to metric serialization.
+
+metrics:
+  - name: roundtrip_revenue
+    description: "Revenue, carrying every optional field the dump writes"
+    sql_expression: "SUM(amount)"
+    source_model: analytics.orders
+    filters: ["status != 'cancelled'"]
+    domains: [revenue]
+    tier: [north_star]
+    indicator_kind: lagging
+    business_owner: revenue-analytics
+    operational_owner: data-platform
+    last_reviewed: 2026-05-01
+    decompositions:
+      - operator: product
+        operands: [roundtrip_customers, roundtrip_arpu]
+        convention: fold_into
+        convention_operand: roundtrip_arpu
+    drill_by:
+      - {dimension: region, column: analytics.customers.region}
+
+  - name: roundtrip_customers
+    description: "Paying customers — leaf operand"
+    sql_expression: "COUNT(DISTINCT customer_id)"
+
+  - name: roundtrip_arpu
+    description: "Revenue per customer — leaf operand"
+    sql_expression: "SUM(amount) / NULLIF(COUNT(DISTINCT customer_id), 0)"
+
 relationships:
   - from: analytics.orders.customer_id
     to: analytics.customers.id

--- a/tests/test_ard/test_catalog_entry.py
+++ b/tests/test_ard/test_catalog_entry.py
@@ -195,14 +195,69 @@ def test_tags_include_wildcard_schemas() -> None:
 # A digest published against this fixture. Hardcoded on purpose: comparing two
 # freshly-built contracts to each other passes just as happily when *both* have
 # shifted, which is precisely the failure a new schema field causes.
+#
+# Re-pinned once, in the commit that fixed #73. The old value was computed over a
+# semantic source with no `metrics:` key at all, so it could not see any change
+# to metric serialization — every optional field added to `_dump_metric` since it
+# was written could have been made unconditional with this test still green, while
+# moving the digest of every real contract. The fixture now carries metrics
+# exercising each of those fields, and the value below is the digest over them.
+#
+# Changing this constant is the one edit that can launder a real regression into
+# the baseline. Any commit that touches it must show the fixture change beside it
+# and say why the new value is expected.
 _PINNED_ROUNDTRIP_DIGEST = (
-    "sha256:898c842e0b97e06f50eeef694869432530ebc8ab8340d7d5c1e9d735cb052673"
+    "sha256:d5aac3e3b76c8ff2458d8388c19de0111c58e9a5fd376f9cebe7c76220d793f8"
 )
 
 
 def test_roundtrip_contract_digest_is_pinned(fixtures_dir: Path) -> None:
     """Any new field that serializes moves every published ARD attestation."""
     assert contract_digest(_contract(fixtures_dir)) == _PINNED_ROUNDTRIP_DIGEST
+
+
+def test_pinned_contract_actually_exercises_metric_serialization(
+    fixtures_dir: Path,
+) -> None:
+    """Guard on the guard: the pin is only broad if the fixture has metrics.
+
+    This is the regression test for #73. The pin spent its whole life over a
+    semantic source with no ``metrics:`` key, so it silently covered nothing in
+    ``_dump_metric`` — a state indistinguishable from working, because the
+    assertion passed either way. Anyone who strips the metrics back out fails
+    here rather than quietly narrowing the pin to relationships again.
+
+    Asserting on the *canonical bytes* rather than the loaded source is
+    deliberate: what matters is that these fields reach the digest, not merely
+    that the fixture declares them.
+    """
+    payload = json.loads(contract_canonical_bytes(_contract(fixtures_dir)))
+    metrics = payload["semantic"]["source"]["inline"]["metrics"]
+    assert metrics, "pinned fixture declares no metrics — the pin covers nothing"
+
+    parent = next(m for m in metrics if m["name"] == "roundtrip_revenue")
+    # Every optional field `_dump_metric` writes, so making any of them
+    # unconditional moves the pin instead of passing unnoticed.
+    for field in (
+        "source_model",
+        "filters",
+        "domains",
+        "tier",
+        "indicator_kind",
+        "business_owner",
+        "operational_owner",
+        "last_reviewed",
+        "decompositions",
+        "drill_by",
+    ):
+        assert field in parent, f"pinned fixture no longer exercises {field!r}"
+    assert parent["decompositions"][0]["convention"] == "fold_into"
+
+    # And a leaf metric, so the omit-when-empty branches are exercised too: a
+    # regression that emits `"decompositions": []` for leaves must move the pin.
+    leaf = next(m for m in metrics if m["name"] == "roundtrip_arpu")
+    assert "decompositions" not in leaf
+    assert "drill_by" not in leaf
 
 
 def test_expected_extras_is_not_digest_bearing(fixtures_dir: Path) -> None:


### PR DESCRIPTION
Closes #73.

## The problem

`_PINNED_ROUNDTRIP_DIGEST` is the repo's broadest guard against canonical-bytes drift — one changed byte anywhere in the payload fails it, with no test author needing to have anticipated the field.

It was computed over a semantic source with **no `metrics:` key at all**. `roundtrip_contract.yml` points at `relationships_checker.yml`, which declares only `relationships:`. So `_dump_metric` was never called, and the pin could not see any change to metric serialization.

That is worse than a missing test, because **the assertion passed either way**. Every optional field added to `_dump_metric` since the pin was written could have been made unconditional — moving the digest of every real contract and invalidating every published ARD attestation — with this test still green.

## The fix

The fixture now carries three metrics:

- `roundtrip_revenue` — exercises **every** optional field the dump writes: `source_model`, `filters`, `domains`, `tier`, `indicator_kind`, both owners, `last_reviewed`, `decompositions` (with a `convention`), `drill_by`.
- `roundtrip_customers` / `roundtrip_arpu` — leaves, so the omit-when-empty branches are exercised too.

**Blast radius was exactly the two pinned assertions.** The other 1068 tests passed unchanged, so nothing else depended on the fixture being metric-less. I extended the existing fixture rather than repointing `roundtrip_contract.yml` at a new one, because `test_digest_is_independent_of_source_path` hardcodes `relationships_checker.yml` as "the same file" the contract points at — repointing would have broken that test and made its comment false.

## Proof the guard now guards

Mutation test: removing the `if m.decompositions:` branch in `_dump_metric`, so leaf metrics emit `"decompositions": []`, now **fails** the pin. Restoring it passes. Before this change that mutation was unreachable — `_dump_metric` was never called.

That is precisely the regression class the omit-when-empty discipline exists to prevent; it kept leaf metrics byte-identical across the 0.28 upgrade and was extended to two more keys in 0.43.0.

## Guard on the guard

`test_pinned_contract_actually_exercises_metric_serialization` asserts the pinned contract's **canonical bytes** contain each of those fields — not merely that the fixture declares them, since what matters is that they reach the digest. Anyone who strips the metrics back out fails loudly instead of silently narrowing the pin to relationships again.

## On re-pinning

Changing this constant is the one edit that can launder a real regression into the baseline. The constant now carries its provenance inline and says so, and this PR shows the fixture change beside the new value.

1071 tests pass, `prek run --all-files` clean, all three examples run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)