### PR TITLE
fix: attribute_change validates operator and arity (v0.43.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.43.1] - 2026-08-18
+
+### Fixed
+
+- **`attribute_change` validates operator and arity, like the sibling it mirrors.** It is public, accepts an arbitrary `MetricDefinition`, and its own comments state it cannot assume the object came through `validate_decompositions` at load — but it re-validated only the *convention*. `reconcile_decomposition` validates operator **and** arity up front for exactly that reason, before running a single query. Without the same block, malformed decompositions surfaced as interpreter errors from inside the arithmetic rather than the `ValueError` the module commits to: a 1-operand `ratio` raised `IndexError` from the zero-denominator guard's `operands[1]`, a 3-operand `ratio` or `difference` raised `too many values to unpack` naming nothing about the contract, and an operand-less `product` raised `ZeroDivisionError` from inside `_place`. Unreachable for any contract-loaded metric, since `validate_decompositions` rejects all four shapes at load — but the asymmetry between two kernels with the same stated precondition posture is the kind that gets copied. ([#72](https://github.com/flyersworder/agentic-data-contracts/issues/72))
+
+### Internal
+
+- **The pinned round-trip digest now covers metric serialization.** `_PINNED_ROUNDTRIP_DIGEST` is the repo's broadest guard against canonical-bytes drift, but it was computed over a semantic source with no `metrics:` key at all, so `_dump_metric` was never called and it could not see any change to metric serialization. That is worse than a missing test, because the assertion passed either way: every optional field added to `_dump_metric` since the pin was written could have been made unconditional — moving the digest of every real contract and invalidating every published ARD attestation — with the test still green. The fixture now carries a metric exercising every optional field the dump writes plus two leaves for the omit-when-empty branches, verified by mutation (removing the `if m.decompositions:` guard now fails the pin), and a companion test asserts the pinned contract's canonical bytes still carry those fields so the coverage cannot be silently narrowed again. No shipped code changed. ([#73](https://github.com/flyersworder/agentic-data-contracts/issues/73))
+
 ## [0.43.0] - 2026-08-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-data-contracts"
-version = "0.43.0"
+version = "0.43.1"
 description = "YAML-first, domain-driven data governance for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agentic_data_contracts/validation/attribution.py
+++ b/src/agentic_data_contracts/validation/attribution.py
@@ -184,8 +184,10 @@ def attribute_change(
     several defensible numbers with no way to tell which was used.
     """
     from agentic_data_contracts.semantic.base import (
+        _BINARY_OPERATORS,
         _CROSS_TERM_OPERATORS,
         VALID_CONVENTIONS,
+        VALID_OPERATORS,
     )
     from agentic_data_contracts.validation.reconciliation import _apply_operator
 
@@ -193,6 +195,30 @@ def attribute_change(
     operands = list(decomp.operands)
     _check_keys(before, "before", operands, metric.name)
     _check_keys(after, "after", operands, metric.name)
+
+    # Operator and arity, before any arithmetic — the same up-front block
+    # ``reconcile_decomposition`` runs before its first query, and for the same
+    # reason: this function cannot assume the decomposition came through
+    # ``validate_decompositions``. Without it a malformed shape surfaced from
+    # inside the arithmetic instead — a 1-operand ratio as ``IndexError`` on the
+    # zero-denominator guard below, a 3-operand ratio as an unpacking error
+    # naming nothing about the contract, an operand-less product as
+    # ``ZeroDivisionError`` in ``_place``.
+    if decomp.operator not in VALID_OPERATORS:
+        raise ValueError(
+            f"unknown decomposition operator {decomp.operator!r}; "
+            f"expected one of {sorted(VALID_OPERATORS)}"
+        )
+    if decomp.operator in _BINARY_OPERATORS and len(operands) != 2:
+        raise ValueError(
+            f"operator {decomp.operator!r} requires exactly 2 operands, "
+            f"got {len(operands)}"
+        )
+    if decomp.operator not in _BINARY_OPERATORS and len(operands) < 2:
+        raise ValueError(
+            f"operator {decomp.operator!r} requires at least 2 operands, "
+            f"got {len(operands)}"
+        )
 
     if decomp.operator in _CROSS_TERM_OPERATORS and decomp.convention is None:
         raise ValueError(

--- a/tests/test_validation/test_attribution.py
+++ b/tests/test_validation/test_attribution.py
@@ -420,3 +420,78 @@ class TestInteractionKeyCollision:
             reported={INTERACTION_KEY: 15.0, "users": 25.0},
         )
         assert r.matches is True
+
+
+class TestOperatorAndArityPreconditions:
+    """Mirrors the up-front block ``reconcile_decomposition`` already has.
+
+    ``attribute_change`` is public and accepts an arbitrary
+    ``MetricDefinition``; its own comments say it cannot assume the object came
+    through ``validate_decompositions`` at load. Before this, malformed shapes
+    surfaced as interpreter errors from inside the arithmetic — ``IndexError``,
+    an unpacking ``ValueError`` naming nothing about the contract, or
+    ``ZeroDivisionError`` — rather than the ``ValueError`` the module commits
+    to. See #72.
+    """
+
+    def test_unknown_operator_raises_before_any_arithmetic(self) -> None:
+        with pytest.raises(ValueError, match="unknown decomposition operator"):
+            attribute_change(
+                _metric(None, operator="power", operands=["a", "b"]),
+                before={"a": 1.0, "b": 2.0},
+                after={"a": 2.0, "b": 3.0},
+            )
+
+    def test_ratio_with_one_operand_raises(self) -> None:
+        # Previously IndexError from the zero-denominator guard's operands[1].
+        with pytest.raises(ValueError, match="requires exactly 2 operands"):
+            attribute_change(
+                _metric("explicit", operator="ratio", operands=["n"]),
+                before={"n": 1.0},
+                after={"n": 2.0},
+            )
+
+    def test_ratio_with_three_operands_raises(self) -> None:
+        # Previously "too many values to unpack (expected 2, got 3)".
+        with pytest.raises(ValueError, match="requires exactly 2 operands"):
+            attribute_change(
+                _metric("explicit", operator="ratio", operands=["a", "b", "c"]),
+                before={"a": 1.0, "b": 2.0, "c": 3.0},
+                after={"a": 2.0, "b": 3.0, "c": 4.0},
+            )
+
+    def test_difference_with_three_operands_raises(self) -> None:
+        with pytest.raises(ValueError, match="requires exactly 2 operands"):
+            attribute_change(
+                _metric(None, operator="difference", operands=["a", "b", "c"]),
+                before={"a": 1.0, "b": 2.0, "c": 3.0},
+                after={"a": 2.0, "b": 3.0, "c": 4.0},
+            )
+
+    def test_product_with_no_operands_raises(self) -> None:
+        # Previously ZeroDivisionError from split_evenly dividing by len().
+        with pytest.raises(ValueError, match="requires at least 2 operands"):
+            attribute_change(
+                _metric("split_evenly", operator="product", operands=[]),
+                before={},
+                after={},
+            )
+
+    def test_sum_with_one_operand_raises(self) -> None:
+        with pytest.raises(ValueError, match="requires at least 2 operands"):
+            attribute_change(
+                _metric(None, operator="sum", operands=["a"]),
+                before={"a": 1.0},
+                after={"a": 2.0},
+            )
+
+    def test_check_attribution_inherits_the_guards(self) -> None:
+        # check_attribution wraps attribute_change, so it must raise the same
+        # way rather than reaching its own key-set comparison first.
+        with pytest.raises(ValueError, match="requires exactly 2 operands"):
+            check_attribution(
+                _metric("explicit", operator="ratio", operands=["n"]),
+                before={"n": 1.0},
+                after={"n": 2.0},
+                reported={"n": 1.0},
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ overrides = [{ name = "python-dotenv", specifier = ">=1.2.2" }]
 
 [[package]]
 name = "agentic-data-contracts"
-version = "0.43.0"
+version = "0.43.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #72.

## The asymmetry

`attribute_change` carries an explicit comment that it cannot assume its `MetricDefinition` came through `validate_decompositions` at load — and then re-validates only the **convention**. `reconcile_decomposition`, the sibling it is modelled on, validates the operator **and** the arity up front, before running a single query, for exactly that reason.

## What that cost

Malformed decompositions surfaced as interpreter errors from inside the arithmetic rather than the `ValueError` the module commits to:

| Input | Before | After |
|---|---|---|
| `ratio`, 1 operand | `IndexError: list index out of range` | `ValueError: operator 'ratio' requires exactly 2 operands, got 1` |
| `ratio`, 3 operands | `ValueError: too many values to unpack (expected 2, got 3)` | `ValueError: operator 'ratio' requires exactly 2 operands, got 3` |
| `difference`, 3 operands | `ValueError: too many values to unpack (expected 2, got 3)` | `ValueError: operator 'difference' requires exactly 2 operands, got 3` |
| `product`, 0 operands | `ZeroDivisionError: division by zero` | `ValueError: operator 'product' requires at least 2 operands, got 0` |

The `IndexError` came from the zero-denominator guard indexing `operands[1]` — which is why the new block has to sit **before** it. The two unpacking errors are technically the documented type but name nothing about the contract.

## Scope

Unreachable for any contract-loaded metric: `validate_decompositions` rejects all four shapes at load. But `attribute_change` is public, and the asymmetry between two kernels with the same stated precondition posture is the kind that gets copied into a third.

This is the remaining half of a cleanup the same release started, when the `fold_into` / `convention_operand` pairing moved out of an `assert` — which vanishes entirely under `python -O` — into a real `ValueError`.

## Version

**0.43.1.** This changes what a public function raises for malformed input, which is user-observable — a patch, not a minor, since there is no new functionality. The CHANGELOG also records #73's pinned-digest coverage fix under `Internal`, since that shipped in #75 with no version of its own (test-only, zero `src/` changes).

## Verification

7 new tests covering every row above plus an unknown operator and `check_attribution` inheriting the guards. 1078 tests pass, `prek run --all-files` clean. The pilot table is unchanged — `split_evenly` still gives 2000/1250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)