### PR TITLE
feat(dce): run the ungolded tasks, and build the leaderboard submission file

### DIFF
--- a/experiments/dabstep-contract-eval/.gitignore
+++ b/experiments/dabstep-contract-eval/.gitignore
@@ -12,3 +12,11 @@ __pycache__/
 # snapshot blocked the next model's sweep from starting at all.
 results/*.jsonl.snapshot
 results/*.jsonl.lock
+
+# A built submission file. Not ignored, it makes the tree dirty for the NEXT
+# runner invocation -- `assert_clean_tree` exempts only that sweep's own
+# `--out` and its sidecars -- which blocks a truncation resume
+# (`deploy/supervise.sh` retries automatically on exit 2), a `--retry` pass,
+# or another model's sweep. The same failure `.snapshot` above records.
+# Nothing is lost: a submission is derived from tracked results rows.
+submission*.jsonl

--- a/experiments/dabstep-contract-eval/.gitignore
+++ b/experiments/dabstep-contract-eval/.gitignore
@@ -15,8 +15,13 @@ results/*.jsonl.lock
 
 # A built submission file. Not ignored, it makes the tree dirty for the NEXT
 # runner invocation -- `assert_clean_tree` exempts only that sweep's own
-# `--out` and its sidecars -- which blocks a truncation resume
-# (`deploy/supervise.sh` retries automatically on exit 2), a `--retry` pass,
-# or another model's sweep. The same failure `.snapshot` above records.
+# `--out` and its sidecars -- which blocks a truncation resume, a `--retry`
+# pass, or another model's sweep. The same failure `.snapshot` above records.
 # Nothing is lost: a submission is derived from tracked results rows.
-submission*.jsonl
+#
+# ANCHORED, and that leading slash is load-bearing. Unanchored, git matches
+# the pattern at every depth, including `results/submission.jsonl` -- which
+# is a paid sweep's output, and `results/` is deliberately tracked. An
+# un-anchored rule silently keeps a 450-task results file out of git while
+# its own comment above claims submissions derive from tracked rows.
+/submission*.jsonl

--- a/experiments/dabstep-contract-eval/README.md
+++ b/experiments/dabstep-contract-eval/README.md
@@ -20,7 +20,7 @@ rows and exit 2.
 ```bash
 cd experiments/dabstep-contract-eval
 uv sync
-uv run pytest -q                     # 369 tests, deterministic and offline
+uv run pytest -q                     # 373 tests, deterministic and offline
 uv run python -m dce.prepare         # downloads DABStep, builds the DuckDB, reconstructs golds
 ```
 
@@ -332,8 +332,11 @@ claim that they did not exist.
 `dce.submit` emits `{"task_id", "agent_answer"}` per line, reading through
 `latest_rows` so a retried unit contributes its final answer rather than a
 stale `error` row's empty string. It **refuses to write at all** — leaving no
-partial file behind — if any task has no row, has a harness-failure verdict,
-or has a blank answer, and names them. A submission is effectively one-shot
+partial file behind — if any task has no row, has a verdict carrying no reply
+(`hit_limit`, `error`, `post_run_error`, `construction_error`), or has a blank
+answer, and names them. `scoring_error` *is* submittable: it means a real
+answer came back and our local scorer raised on it, which is the leaderboard's
+call to make. A submission is effectively one-shot
 per agent name and the Space scores a missing task as wrong, so a short file
 is worse than no file. `--results` takes several files, so a fresh all-450
 sweep and a spliced 401 + 49 both work.

--- a/experiments/dabstep-contract-eval/README.md
+++ b/experiments/dabstep-contract-eval/README.md
@@ -20,7 +20,7 @@ rows and exit 2.
 ```bash
 cd experiments/dabstep-contract-eval
 uv sync
-uv run pytest -q                     # 384 tests, deterministic and offline
+uv run pytest -q                     # 387 tests, deterministic and offline
 uv run python -m dce.prepare         # downloads DABStep, builds the DuckDB, reconstructs golds
 ```
 
@@ -315,12 +315,17 @@ this:
 ```bash
 # 1. answer every task, including the 49 that cannot be scored locally
 uv run python -m dce.runner --ungolded run --arms contract \
-    --models z-ai/glm-5.3-flash --max-spend 2.00 --out results/submission.jsonl
+    --models z-ai/glm-5.3-flash --max-spend 2.00 --out results/glm-all450.jsonl
 
 # 2. build the file the Space wants
-uv run python -m dce.submit --results results/submission.jsonl \
+uv run python -m dce.submit --results results/glm-all450.jsonl \
     --arm contract --model z-ai/glm-5.3-flash --out submission.jsonl
 ```
+
+The sweep's output lives in `results/` and stays **tracked** — the
+tamper-evidence claim depends on result rows being readable in git history.
+Only the built `submission*.jsonl` at the experiment root is gitignored, and
+that rule is anchored precisely so it cannot swallow a results file.
 
 `--ungolded run` does **not** score the extra tasks. They reach `run_task` as
 `gold=None`; a clean run records `verdict: "ungraded"`, and one that trips a

--- a/experiments/dabstep-contract-eval/README.md
+++ b/experiments/dabstep-contract-eval/README.md
@@ -20,7 +20,7 @@ rows and exit 2.
 ```bash
 cd experiments/dabstep-contract-eval
 uv sync
-uv run pytest -q                     # 379 tests, deterministic and offline
+uv run pytest -q                     # 384 tests, deterministic and offline
 uv run python -m dce.prepare         # downloads DABStep, builds the DuckDB, reconstructs golds
 ```
 
@@ -345,7 +345,10 @@ per agent name and the Space scores a missing task as wrong, so a short file
 is worse than no file. `--results` takes several files, so a fresh all-450
 sweep and a spliced 401 + 49 both work. `--out` may not name one of the
 `--results` files, and an empty submission is refused rather than written as a
-blank line.
+blank line. Spliced rows are checked for provenance: a disagreement on
+`contract_digest` is refused outright (two contracts is two agents), while
+`commit_sha`, `scorer` and `golds_hash` differences are printed — a splice
+spans two commits by construction, so refusing on that would ban this flow.
 
 Uploading is manual and deliberately not automated here: the Space wants a
 browser and metadata (agent name, model family, whether the code is open) that

--- a/experiments/dabstep-contract-eval/README.md
+++ b/experiments/dabstep-contract-eval/README.md
@@ -20,7 +20,7 @@ rows and exit 2.
 ```bash
 cd experiments/dabstep-contract-eval
 uv sync
-uv run pytest -q                     # 373 tests, deterministic and offline
+uv run pytest -q                     # 379 tests, deterministic and offline
 uv run python -m dce.prepare         # downloads DABStep, builds the DuckDB, reconstructs golds
 ```
 
@@ -323,11 +323,15 @@ uv run python -m dce.submit --results results/submission.jsonl \
 ```
 
 `--ungolded run` does **not** score the extra tasks. They reach `run_task` as
-`gold=None` and are recorded `verdict: "ungraded"`, a verdict in neither
-`ANSWER_VERDICTS` nor `HARNESS_VERDICTS`, so no accuracy figure and no
-harness-failure rate in `dce.stats` can reach them. `dce.stats` prints
-`ungraded=N` on any arm that has some, because dropping rows silently is a
-claim that they did not exist.
+`gold=None`; a clean run records `verdict: "ungraded"`, and one that trips a
+cap or errors keeps its harness verdict with `gold: null`. `dce.stats` cuts on
+**the missing gold, not the verdict** — a verdict-keyed cut would let a capped
+ungolded task into the accuracy denominator — so no accuracy figure and no
+harness-failure rate can reach any of them. They are reported on their own
+line (`ungolded: N row(s) …; M harness failure(s) among them`), because
+dropping rows silently is a claim that they did not exist, and because a cap
+trip across those 49 must be counted rather than hidden by its exclusion from
+the rate.
 
 `dce.submit` emits `{"task_id", "agent_answer"}` per line, reading through
 `latest_rows` so a retried unit contributes its final answer rather than a
@@ -339,7 +343,9 @@ answer came back and our local scorer raised on it, which is the leaderboard's
 call to make. A submission is effectively one-shot
 per agent name and the Space scores a missing task as wrong, so a short file
 is worse than no file. `--results` takes several files, so a fresh all-450
-sweep and a spliced 401 + 49 both work.
+sweep and a spliced 401 + 49 both work. `--out` may not name one of the
+`--results` files, and an empty submission is refused rather than written as a
+blank line.
 
 Uploading is manual and deliberately not automated here: the Space wants a
 browser and metadata (agent name, model family, whether the code is open) that

--- a/experiments/dabstep-contract-eval/README.md
+++ b/experiments/dabstep-contract-eval/README.md
@@ -20,7 +20,7 @@ rows and exit 2.
 ```bash
 cd experiments/dabstep-contract-eval
 uv sync
-uv run pytest -q                     # 348 tests, deterministic and offline
+uv run pytest -q                     # 369 tests, deterministic and offline
 uv run python -m dce.prepare         # downloads DABStep, builds the DuckDB, reconstructs golds
 ```
 
@@ -130,7 +130,8 @@ uv run python -m dce.stats results/smoke12.jsonl
 | `--out` | `results/results.jsonl` | One JSON row per `(task, arm, model)`. Appended to, never rewritten. |
 | `--db` | `data/dabstep.duckdb` | The pristine warehouse. Each process runs against a working *copy*. |
 | `--golds` | `data/golds.json` | The gold envelope. Its `revision`, `threshold` and content hash are all checked. |
-| `--tasks` | `data/tasks.json` | Task list; filtered to those that have a gold. |
+| `--tasks` | `data/tasks.json` | Task list; filtered by `--ungolded`. |
+| `--ungolded` | `skip` | What to do with the 49 tasks that have no reconstructed gold. `skip` is every scoring sweep. `run` answers them **unscored** (`verdict: ungraded`) — only a [leaderboard submission](#leaderboard-submission) needs it. |
 | `--workers` | `1` | Task groups to run concurrently, each on its own working copy. See [Unattended runs](deploy/README.md) before raising it. |
 | `--retry` | none | `error` or `post_run_error` — also re-run rows with that verdict on resume. Both already cost money, which is why neither is retried by default. `construction_error` rows are retried automatically (twice, then given up on loudly). |
 
@@ -304,6 +305,44 @@ Two things to check at the **smoke** run, not after the sweep:
    it is invisible in the dollar figures. This line is the only place it shows.
 2. **`did NOT see the same task set`.** A sweep that stopped mid task-group
    leaves the arms with different denominators.
+
+## Leaderboard submission
+
+DABStep is 450 tasks; the ablation runs the **401** with a reconstructed gold
+(`dce.golds`). A submission has to answer all 450, so it needs both halves of
+this:
+
+```bash
+# 1. answer every task, including the 49 that cannot be scored locally
+uv run python -m dce.runner --ungolded run --arms contract \
+    --models z-ai/glm-5.3-flash --max-spend 2.00 --out results/submission.jsonl
+
+# 2. build the file the Space wants
+uv run python -m dce.submit --results results/submission.jsonl \
+    --arm contract --model z-ai/glm-5.3-flash --out submission.jsonl
+```
+
+`--ungolded run` does **not** score the extra tasks. They reach `run_task` as
+`gold=None` and are recorded `verdict: "ungraded"`, a verdict in neither
+`ANSWER_VERDICTS` nor `HARNESS_VERDICTS`, so no accuracy figure and no
+harness-failure rate in `dce.stats` can reach them. `dce.stats` prints
+`ungraded=N` on any arm that has some, because dropping rows silently is a
+claim that they did not exist.
+
+`dce.submit` emits `{"task_id", "agent_answer"}` per line, reading through
+`latest_rows` so a retried unit contributes its final answer rather than a
+stale `error` row's empty string. It **refuses to write at all** — leaving no
+partial file behind — if any task has no row, has a harness-failure verdict,
+or has a blank answer, and names them. A submission is effectively one-shot
+per agent name and the Space scores a missing task as wrong, so a short file
+is worse than no file. `--results` takes several files, so a fresh all-450
+sweep and a spliced 401 + 49 both work.
+
+Uploading is manual and deliberately not automated here: the Space wants a
+browser and metadata (agent name, model family, whether the code is open) that
+should be entered by a person. Read `docs/paper-plan.md`'s *leaderboard
+submission* section first — it records the conditions the submission is
+committed to, including submitting one arm only.
 
 ## Accepted gaps
 

--- a/experiments/dabstep-contract-eval/dce/agent.py
+++ b/experiments/dabstep-contract-eval/dce/agent.py
@@ -646,7 +646,7 @@ def build_result_row(
     model: str,
     answer: str,
     answer_normalized: str,
-    gold: str,
+    gold: str | None,
     verdict: str,
     forced_answer: bool,
     trace_path: str | None,
@@ -850,7 +850,7 @@ def _priced_fallback_row(
     task: dict,
     arm: str,
     model: str,
-    gold: str,
+    gold: str | None,
     golds_hash: str,
     usage,
     verdict: str,
@@ -1162,7 +1162,7 @@ def run_task(
     model: str,
     db_path: Path,
     docs: dict[str, str],
-    gold: str,
+    gold: str | None,
     *,
     golds_hash: str,
     max_tool_calls: int = MAX_TOOL_CALLS,
@@ -1415,10 +1415,21 @@ def run_task(
             # verdict instead, and the real answer this run produced is
             # preserved either way.
             if verdict == "unset":
-                try:
-                    verdict = "correct" if score(answer, gold) else "incorrect"
-                except Exception:
-                    verdict = "scoring_error"
+                if gold is None:
+                    # No gold EXISTS for this task (49 of DABStep's 450 are
+                    # unreconstructable -- see `dce.golds`). Not a scoring
+                    # failure and not a wrong answer: scoring it against the
+                    # `""` a plain `dict.get` would hand back marks every one
+                    # of them `incorrect` and feeds them straight into
+                    # `dce.stats`' accuracy denominators. `ungraded` is in
+                    # neither ANSWER_VERDICTS nor HARNESS_VERDICTS, so no
+                    # accuracy or failure-rate arithmetic can reach it.
+                    verdict = "ungraded"
+                else:
+                    try:
+                        verdict = "correct" if score(answer, gold) else "incorrect"
+                    except Exception:
+                        verdict = "scoring_error"
 
             answer_normalized = _clean(answer)
 

--- a/experiments/dabstep-contract-eval/dce/runner.py
+++ b/experiments/dabstep-contract-eval/dce/runner.py
@@ -929,7 +929,7 @@ def _construction_error_row(
     task: dict,
     arm: str,
     model: str,
-    gold: str,
+    gold: str | None,
     golds_hash: str,
     exc: AgentConstructionError,
 ) -> dict:
@@ -1262,7 +1262,12 @@ def _run_group(
     flag instead of `break`ing a loop the caller no longer owns.
     """
     for task_id, arm, model in group:
-        gold = golds.get(task_id, "")
+        # `.get` WITHOUT a default: a task carrying no reconstructed gold
+        # must reach `run_task` as `None`, which it records `ungraded`.
+        # A `""` default would be scored instead, manufacturing an
+        # `incorrect` verdict on a task that has no right answer to
+        # compare against — and that verdict counts. See `select_tasks`.
+        gold = golds.get(task_id)
         try:
             row = run_task_fn(
                 by_id[task_id],
@@ -1589,6 +1594,32 @@ def _stratified_sample(tasks: list[dict], n: int) -> list[dict]:
     return sampled
 
 
+#: How `select_tasks` treats a task with no reconstructed gold.
+#: `"skip"` is every scoring sweep: unscoreable tasks are not run.
+#: `"run"` is a leaderboard submission, which needs an answer for all 450.
+UNGOLDED_MODES: tuple[str, ...] = ("skip", "run")
+
+
+def select_tasks(tasks: list[dict], golds: dict, ungolded: str = "skip") -> list[dict]:
+    """The tasks a sweep will run, given the golds it can score against.
+
+    This used to be an inline comprehension in `main`, and it silently
+    decided something load-bearing: 49 of DABStep's 450 tasks have no
+    reconstructable gold (`dce.golds`), so a scored sweep runs 401. That is
+    right for the ablation and wrong for a leaderboard submission, which is
+    graded on all 450 by DABStep's own withheld answers.
+
+    `ungolded="run"` admits them. They are still not scored — `_run_group`
+    passes `None` rather than `""`, and `run_task` records `ungraded` — so
+    admitting them cannot move an accuracy figure, only fill in answers.
+    """
+    if ungolded not in UNGOLDED_MODES:
+        raise ValueError(f"ungolded must be one of {UNGOLDED_MODES}, got {ungolded!r}")
+    if ungolded == "run":
+        return list(tasks)
+    return [t for t in tasks if t["task_id"] in golds]
+
+
 def _load_golds(path: Path) -> tuple[dict[str, str], str]:
     """Read the golds envelope and return (task_id -> answer map, gold hash).
 
@@ -1784,6 +1815,16 @@ def main() -> None:
     parser.add_argument("--golds", type=Path, default=Path("data/golds.json"))
     parser.add_argument("--tasks", type=Path, default=Path("data/tasks.json"))
     parser.add_argument(
+        "--ungolded",
+        choices=UNGOLDED_MODES,
+        default="skip",
+        help=(
+            "what to do with tasks that have no reconstructed gold: "
+            "skip them (default, every scoring sweep) or run them "
+            "unscored, which a leaderboard submission needs"
+        ),
+    )
+    parser.add_argument(
         "--traces",
         type=Path,
         default=None,
@@ -1862,7 +1903,9 @@ def main() -> None:
         )
 
     golds, golds_hash = _load_golds(args.golds)
-    tasks = [t for t in json.loads(args.tasks.read_text()) if t["task_id"] in golds]
+    tasks = select_tasks(
+        json.loads(args.tasks.read_text()), golds, ungolded=args.ungolded
+    )
     if args.n:
         tasks = _stratified_sample(tasks, args.n)
 

--- a/experiments/dabstep-contract-eval/dce/stats.py
+++ b/experiments/dabstep-contract-eval/dce/stats.py
@@ -692,6 +692,13 @@ def _unequal_task_set_warning(rows: list[dict], model: str) -> list[str]:
     from the pairing) and the Wilson intervals silently narrow or widen on.
     Nothing else in this module would say a word about it.
     """
+    # `_graded`, like every other denominator in this module. Without it,
+    # `--ungolded run --arms contract` resumed into an existing multi-arm
+    # file -- the only way to add the 49 without re-paying for the 401 --
+    # leaves the contract arm holding 49 rows no other arm has, and this
+    # warning reads that as a lopsided sweep. It would then tell the operator
+    # to pay to run 49 unscoreable tasks on three more arms.
+    rows = _graded(rows)
     by_arm = {
         arm: {
             row.get("task_id")

--- a/experiments/dabstep-contract-eval/dce/stats.py
+++ b/experiments/dabstep-contract-eval/dce/stats.py
@@ -375,6 +375,24 @@ def _scored(rows: list[dict]) -> list[dict]:
     return [row for row in rows if row.get("verdict") in ANSWER_VERDICTS]
 
 
+def _graded(rows: list[dict]) -> list[dict]:
+    """Rows that ACCURACY arithmetic may see: everything except the tasks
+    with no gold to score against.
+
+    Deliberately not the same cut as `_scored`. A harness failure stays in
+    (STRICT accuracy counts it against the arm, which is the point of the
+    STRICT view); an `ungraded` row comes out, because there is no right
+    answer it could have missed.
+
+    Every accuracy or failure-rate denominator must go through this. Cost,
+    `db_corrupted` and the instrumentation means must NOT: those rows were
+    really billed and their working copies really were checked, and
+    dropping them there would understate spend and silently delete
+    governance evidence on the 49 tasks a submission sweep adds.
+    """
+    return [row for row in rows if row.get("verdict") not in UNGRADED_VERDICTS]
+
+
 def _failure_counts(rows: list[dict]) -> dict[str, int]:
     """Count of rows by verdict, restricted to harness-outcome verdicts."""
     counts: dict[str, int] = defaultdict(int)
@@ -418,19 +436,22 @@ def _summarize(rows: list[dict], raw_rows: list[dict]) -> dict:
     that is not entirely arm C, so a mixed or ungoverned slice reports
     nothing rather than a structural zero.
     """
-    # BEFORE any arithmetic. `strict_n` is `len(rows)`, so an ungraded row
-    # left in `rows` counts against STRICT accuracy exactly as a wrong
-    # answer would, and dilutes `failure_rate` -- which is the denominator
-    # HARNESS_FAILURE_RATE_THRESHOLD is compared against. Both would read as
-    # a quieter, better-behaved run than the file actually describes.
-    ungraded_n = sum(row.get("verdict") in UNGRADED_VERDICTS for row in rows)
-    rows = [row for row in rows if row.get("verdict") not in UNGRADED_VERDICTS]
-    scored_rows = _scored(rows)
+    # `graded_rows` for the accuracy block, the FULL slice for everything
+    # else. `strict_n` was `len(rows)`, so an ungraded row counted against
+    # STRICT accuracy exactly as a wrong answer would, and diluted
+    # `failure_rate` -- the denominator HARNESS_FAILURE_RATE_THRESHOLD is
+    # compared against -- so both read as a quieter run than the file
+    # describes. Filtering `rows` outright instead was its own bug: it also
+    # took those rows out of `usd_final`, `_corruption_counts` and
+    # `_instrumentation`, where they belong (see `_graded`).
+    graded_rows = _graded(rows)
+    ungraded_n = len(rows) - len(graded_rows)
+    scored_rows = _scored(graded_rows)
     scored_ok = sum(row.get("verdict") == "correct" for row in scored_rows)
     scored_n = len(scored_rows)
-    strict_ok = sum(row.get("verdict") == "correct" for row in rows)
-    strict_n = len(rows)
-    failures = _failure_counts(rows)
+    strict_ok = sum(row.get("verdict") == "correct" for row in graded_rows)
+    strict_n = len(graded_rows)
+    failures = _failure_counts(graded_rows)
     failure_rate = sum(failures.values()) / strict_n if strict_n else 0.0
     return {
         "scored_ok": scored_ok,
@@ -571,11 +592,18 @@ def _scored_bools(rows: list[dict], arm: str) -> dict[str, bool]:
 def _strict_bools(rows: list[dict], arm: str) -> dict[str, bool]:
     """task_id -> correct, for the STRICT McNemar view: every task this arm
     attempted is present, with a harness failure counted as wrong.
+
+    `ungraded` is the one verdict excluded. A harness failure is a real
+    attempt that produced no right answer, which is what STRICT is for; a
+    task with no gold is not an attempt that failed. Pairing them would add
+    concordant false/false pairs — harmless to `p_value`, which uses only
+    discordant pairs, but `n_paired` would claim a comparison over tasks
+    neither arm could be graded on.
     """
     return {
         row.get("task_id", "unknown"): row.get("verdict") == "correct"
         for row in rows
-        if row.get("arm") == arm
+        if row.get("arm") == arm and row.get("verdict") not in UNGRADED_VERDICTS
     }
 
 
@@ -748,8 +776,13 @@ def report(path: Path, *, rescore_stale: bool = True) -> str:
             ]
             lines.append(_format_summary(arm, _summarize(arm_rows, raw_arm_rows)))
 
-            scored_by_level = accuracy_by(_scored(arm_rows), "level")
-            strict_by_level = accuracy_by(arm_rows, "level")
+            # `_graded` here too: this breakdown does not go through
+            # `_summarize`, so it is a second STRICT denominator. Without it
+            # the header line prints `strict 1/1` and the level line right
+            # beneath prints `strict 1/3` off the same rows.
+            graded_arm_rows = _graded(arm_rows)
+            scored_by_level = accuracy_by(_scored(graded_arm_rows), "level")
+            strict_by_level = accuracy_by(graded_arm_rows, "level")
             for level in sorted(set(scored_by_level) | set(strict_by_level)):
                 s_ok, s_n = scored_by_level.get(level, (0, 0))
                 t_ok, t_n = strict_by_level.get(level, (0, 0))

--- a/experiments/dabstep-contract-eval/dce/stats.py
+++ b/experiments/dabstep-contract-eval/dce/stats.py
@@ -37,8 +37,9 @@ than one:
 
   * SCORED accuracy: `correct` / (`correct` + `incorrect`) -- harness
     failures dropped from both halves of the fraction entirely.
-  * STRICT accuracy: `correct` / all rows -- harness failures counted as
-    wrong.
+  * STRICT accuracy: `correct` / all GRADED rows -- harness failures counted
+    as wrong. Rows for a task with no gold are not graded rows; see
+    `_is_ungolded`.
 
 Excluding harness failures (SCORED) flatters whichever arm fails most;
 counting them as wrong (STRICT) instead punishes that arm for what may be
@@ -633,17 +634,23 @@ def _strict_bools(rows: list[dict], arm: str) -> dict[str, bool]:
     """task_id -> correct, for the STRICT McNemar view: every task this arm
     attempted is present, with a harness failure counted as wrong.
 
-    `ungraded` is the one verdict excluded. A harness failure is a real
-    attempt that produced no right answer, which is what STRICT is for; a
-    task with no gold is not an attempt that failed. Pairing them would add
-    concordant false/false pairs — harmless to `p_value`, which uses only
-    discordant pairs, but `n_paired` would claim a comparison over tasks
-    neither arm could be graded on.
+    Ungolded tasks are the one exclusion, and the cut is `_is_ungolded` --
+    the SAME cut `_summarize` makes, keyed on the missing gold rather than on
+    the verdict. Keying it on `verdict in UNGRADED_VERDICTS` (as this did)
+    kept every ungolded task whose run tripped a cap or errored, so the two
+    denominators in one report disagreed: `strict 1/1` per arm above an
+    `n_paired=2` line.
+
+    A harness failure on a GOLDED task is a real attempt that produced no
+    right answer, which is what STRICT is for; a task with no gold is not an
+    attempt that failed. Pairing them adds concordant false/false pairs --
+    harmless to `p_value`, which reads only discordant pairs, but `n_paired`
+    would claim a comparison over tasks neither arm could be graded on.
     """
     return {
         row.get("task_id", "unknown"): row.get("verdict") == "correct"
         for row in rows
-        if row.get("arm") == arm and row.get("verdict") not in UNGRADED_VERDICTS
+        if row.get("arm") == arm and not _is_ungolded(row)
     }
 
 

--- a/experiments/dabstep-contract-eval/dce/stats.py
+++ b/experiments/dabstep-contract-eval/dce/stats.py
@@ -364,6 +364,12 @@ def stale_scorer_rows(rows: list[dict]) -> dict[str, int]:
     now = active_scorer()
     counts: dict[str, int] = defaultdict(int)
     for row in rows:
+        # An ungolded row carries `scorer` like any other (`build_result_row`
+        # sets it unconditionally) but `rescore` skips it — nothing graded it
+        # and nothing will. Counting it both inflates the warning and makes
+        # its claim, that every answered row has been re-graded, false.
+        if _is_ungolded(row):
+            continue
         recorded = row.get("scorer")
         if recorded and recorded != now:
             counts[recorded] += 1
@@ -375,22 +381,45 @@ def _scored(rows: list[dict]) -> list[dict]:
     return [row for row in rows if row.get("verdict") in ANSWER_VERDICTS]
 
 
-def _graded(rows: list[dict]) -> list[dict]:
-    """Rows that ACCURACY arithmetic may see: everything except the tasks
-    with no gold to score against.
+def _is_ungolded(row: dict) -> bool:
+    """This row's task had no gold to score against.
 
-    Deliberately not the same cut as `_scored`. A harness failure stays in
-    (STRICT accuracy counts it against the arm, which is the point of the
-    STRICT view); an `ungraded` row comes out, because there is no right
-    answer it could have missed.
+    Keyed on `gold`, NOT on `verdict`. A task admitted by `--ungolded run`
+    only reaches `verdict: "ungraded"` if `run_task` finishes cleanly; trip a
+    cap or error and the row keeps `hit_limit`/`error`/`post_run_error`/
+    `construction_error` with `gold: None`. A verdict-keyed cut lets those
+    through into `strict_n` and `failure_rate`, which is exactly the
+    invariant `--ungolded run` is supposed to preserve. The verdict is still
+    checked, as a second signal on any row shape that predates `gold` being
+    nullable.
+
+    The `""` default is load-bearing: `_safe_json_dumps`' salvage envelope
+    has no `gold` key at all, and a row we could not even serialise properly
+    is not evidence that its task was ungolded. It stays in the denominator.
+    """
+    return row.get("gold", "") is None or row.get("verdict") in UNGRADED_VERDICTS
+
+
+def _graded(rows: list[dict]) -> list[dict]:
+    """Rows that ACCURACY and FAILURE-RATE arithmetic may see: everything
+    except the tasks with no gold to score against.
+
+    Deliberately not the same cut as `_scored`. A harness failure on a GOLDED
+    task stays in (STRICT accuracy counts it against the arm, which is the
+    point of the STRICT view); every row for an ungolded task comes out,
+    however it ended, because that task is a different population — there is
+    no right answer it could have missed and no accuracy its failure could
+    make less trustworthy.
 
     Every accuracy or failure-rate denominator must go through this. Cost,
     `db_corrupted` and the instrumentation means must NOT: those rows were
-    really billed and their working copies really were checked, and
-    dropping them there would understate spend and silently delete
-    governance evidence on the 49 tasks a submission sweep adds.
+    really billed and their working copies really were checked, and dropping
+    them there would understate spend and silently delete governance evidence
+    on the 49 tasks a submission sweep adds. What leaves the failure RATE is
+    reported on its own line instead, so a cap trip across those 49 is
+    counted rather than hidden.
     """
-    return [row for row in rows if row.get("verdict") not in UNGRADED_VERDICTS]
+    return [row for row in rows if not _is_ungolded(row)]
 
 
 def _failure_counts(rows: list[dict]) -> dict[str, int]:
@@ -445,7 +474,8 @@ def _summarize(rows: list[dict], raw_rows: list[dict]) -> dict:
     # took those rows out of `usd_final`, `_corruption_counts` and
     # `_instrumentation`, where they belong (see `_graded`).
     graded_rows = _graded(rows)
-    ungraded_n = len(rows) - len(graded_rows)
+    ungolded_rows = [row for row in rows if _is_ungolded(row)]
+    ungolded_failures = sum(_failure_counts(ungolded_rows).values())
     scored_rows = _scored(graded_rows)
     scored_ok = sum(row.get("verdict") == "correct" for row in scored_rows)
     scored_n = len(scored_rows)
@@ -462,7 +492,8 @@ def _summarize(rows: list[dict], raw_rows: list[dict]) -> dict:
         "strict_ci": wilson(strict_ok, strict_n),
         "failures": failures,
         "failure_rate": failure_rate,
-        "ungraded_n": ungraded_n,
+        "ungolded_n": len(ungolded_rows),
+        "ungolded_failures": ungolded_failures,
         "corruption": _corruption_counts(rows),
         "usd_final": sum(row.get("usd") or 0.0 for row in rows),
         "usd_total_billed": sum(row.get("usd") or 0.0 for row in raw_rows),
@@ -534,11 +565,20 @@ def _format_summary(label: str, summary: dict) -> str:
         or "none"
     )
     corruption = summary["corruption"]
-    # Silence here is a claim: that no row was set aside. Printed only when
-    # some were, so the four runs already in FINDINGS render unchanged.
-    ungraded_str = (
-        f", ungraded={summary['ungraded_n']} (answered, no gold to score)"
-        if summary["ungraded_n"]
+    # Its OWN line, not appended to the failures list: `failures (0% of
+    # rows): none, ungraded=49` reads as though 49 rows were failures, inside
+    # a line that just said 0%. Silence here is still a claim -- that no row
+    # was set aside -- so the line appears whenever any were, and the harness
+    # failures among them are counted rather than hidden by their exclusion
+    # from `failure_rate`. Absent entirely on the four runs in FINDINGS.
+    ungolded_line = (
+        (
+            f"\n{'':16s} ungolded: {summary['ungolded_n']} row(s) with no gold "
+            f"to score, excluded from accuracy and from the failure rate "
+            f"above; {summary['ungolded_failures']} harness failure(s) among "
+            "them"
+        )
+        if summary["ungolded_n"]
         else ""
     )
     inst = summary["instrumentation"]
@@ -569,9 +609,9 @@ def _format_summary(label: str, summary: dict) -> str:
         f"cost final=${summary['usd_final']:.2f} "
         f"billed=${summary['usd_total_billed']:.2f}{flag}\n"
         f"{'':16s} failures ({summary['failure_rate']:.0%} of rows): "
-        f"{fail_str}{ungraded_str}\n"
+        f"{fail_str}\n"
         f"{'':16s} db_corrupted: true={corruption['corrupted']} "
-        f"unknown={corruption['unknown']}"
+        f"unknown={corruption['unknown']}{ungolded_line}"
         f"{instrumentation_line}{governance_line}"
     )
 

--- a/experiments/dabstep-contract-eval/dce/stats.py
+++ b/experiments/dabstep-contract-eval/dce/stats.py
@@ -169,6 +169,14 @@ HARNESS_VERDICTS: frozenset[str] = frozenset(
     {"hit_limit", "error", "scoring_error", "post_run_error", "construction_error"}
 )
 
+#: A verdict that is neither an answer nor a harness outcome: the task was
+#: run and answered, but no gold EXISTS to score it against (49 of DABStep's
+#: 450 -- see `dce.golds`). A leaderboard submission has to answer those; the
+#: ablation must not count them. Kept out of ANSWER_VERDICTS so no accuracy
+#: arithmetic can reach it, and out of HARNESS_VERDICTS because nothing
+#: failed -- `_summarize` drops these rows before either denominator.
+UNGRADED_VERDICTS: frozenset[str] = frozenset({"ungraded"})
+
 #: Named, not positional: `dce.arms.ARMS` grew a fourth arm
 #: (`contract_hollow`) and the old `ARM_A, ARM_B, ARM_C = ARMS` unpack failed
 #: loudly at import, which is exactly what it was written to do. Resolving by
@@ -410,6 +418,13 @@ def _summarize(rows: list[dict], raw_rows: list[dict]) -> dict:
     that is not entirely arm C, so a mixed or ungoverned slice reports
     nothing rather than a structural zero.
     """
+    # BEFORE any arithmetic. `strict_n` is `len(rows)`, so an ungraded row
+    # left in `rows` counts against STRICT accuracy exactly as a wrong
+    # answer would, and dilutes `failure_rate` -- which is the denominator
+    # HARNESS_FAILURE_RATE_THRESHOLD is compared against. Both would read as
+    # a quieter, better-behaved run than the file actually describes.
+    ungraded_n = sum(row.get("verdict") in UNGRADED_VERDICTS for row in rows)
+    rows = [row for row in rows if row.get("verdict") not in UNGRADED_VERDICTS]
     scored_rows = _scored(rows)
     scored_ok = sum(row.get("verdict") == "correct" for row in scored_rows)
     scored_n = len(scored_rows)
@@ -426,6 +441,7 @@ def _summarize(rows: list[dict], raw_rows: list[dict]) -> dict:
         "strict_ci": wilson(strict_ok, strict_n),
         "failures": failures,
         "failure_rate": failure_rate,
+        "ungraded_n": ungraded_n,
         "corruption": _corruption_counts(rows),
         "usd_final": sum(row.get("usd") or 0.0 for row in rows),
         "usd_total_billed": sum(row.get("usd") or 0.0 for row in raw_rows),
@@ -497,6 +513,13 @@ def _format_summary(label: str, summary: dict) -> str:
         or "none"
     )
     corruption = summary["corruption"]
+    # Silence here is a claim: that no row was set aside. Printed only when
+    # some were, so the four runs already in FINDINGS render unchanged.
+    ungraded_str = (
+        f", ungraded={summary['ungraded_n']} (answered, no gold to score)"
+        if summary["ungraded_n"]
+        else ""
+    )
     inst = summary["instrumentation"]
     instrumentation_line = (
         f"\n{'':16s} tokens/row: in={inst['mean_input_tokens']:.0f} "
@@ -525,7 +548,7 @@ def _format_summary(label: str, summary: dict) -> str:
         f"cost final=${summary['usd_final']:.2f} "
         f"billed=${summary['usd_total_billed']:.2f}{flag}\n"
         f"{'':16s} failures ({summary['failure_rate']:.0%} of rows): "
-        f"{fail_str}\n"
+        f"{fail_str}{ungraded_str}\n"
         f"{'':16s} db_corrupted: true={corruption['corrupted']} "
         f"unknown={corruption['unknown']}"
         f"{instrumentation_line}{governance_line}"

--- a/experiments/dabstep-contract-eval/dce/submit.py
+++ b/experiments/dabstep-contract-eval/dce/submit.py
@@ -78,13 +78,33 @@ def _select(results: list[Path], *, arm: str, model: str) -> dict[str, dict]:
     """
     by_task: dict[str, dict] = {}
     for path in results:
+        # `latest_rows` -> `_read_rows` returns [] for a path that does not
+        # exist, silently. Right for the runner (a fresh `--out`), wrong
+        # here: a typo'd override would contribute nothing, an earlier file
+        # would already cover all 450, no guard would fire, and stale answers
+        # would ship on a one-shot submission.
+        if not path.exists():
+            raise SubmissionError(
+                f"--results {path} does not exist. A missing input reads as "
+                "an empty one, so the submission would quietly be built from "
+                "whatever the other files hold."
+            )
         for row in latest_rows(path):
             if row.get("arm") == arm and row.get("model") == model:
                 by_task[row["task_id"]] = row
     return by_task
 
 
-def _distinct(rows, field: str) -> list[str]:
+#: Stands in for a provenance field a row does not carry, so that "some rows
+#: predate this field" reads as a DISAGREEMENT rather than as agreement. For a
+#: fatal field, absent is the unknown-provenance case the check exists to
+#: refuse.
+ABSENT = "<absent>"
+
+
+def _distinct(rows, field: str, *, absent_counts: bool = False) -> list[str]:
+    if absent_counts:
+        return sorted({str(row.get(field, ABSENT) or ABSENT) for row in rows})
     return sorted({str(row[field]) for row in rows if row.get(field) is not None})
 
 
@@ -92,7 +112,7 @@ def _assert_one_agent(rows) -> None:
     """Refuse a submission assembled from two different contracts."""
     rows = list(rows)
     for field in FATAL_PROVENANCE:
-        values = _distinct(rows, field)
+        values = _distinct(rows, field, absent_counts=True)
         if len(values) > 1:
             raise SubmissionError(
                 f"the selected rows disagree on {field}: {', '.join(values)}. "

--- a/experiments/dabstep-contract-eval/dce/submit.py
+++ b/experiments/dabstep-contract-eval/dce/submit.py
@@ -124,9 +124,35 @@ def write_submission(
 
     The file is built in full BEFORE anything is written, so a refusal
     leaves no partial file on disk -- a half-written submission is the
-    artifact most likely to be uploaded by mistake weeks later.
+    artifact most likely to be uploaded by mistake weeks later. An EMPTY
+    result is refused for the same reason: it would land as a single blank
+    line and read as finished.
+
+    `out` may not be one of `results`; see the comment on the check.
     """
+    # Before reading anything. `build_submission` loads every input into
+    # memory first, so writing over a results file SUCCEEDS: a paid sweep --
+    # verdicts, gold, cost, instrumentation, trace pointers -- is replaced by
+    # a two-field answer list, and only `traces/` survives. The README's own
+    # recipe puts the sweep at `results/submission.jsonl` and the export at
+    # `submission.jsonl`, one path component apart.
+    resolved_out = out.resolve()
+    for path in results:
+        if path.resolve() == resolved_out:
+            raise SubmissionError(
+                f"--out {out} is also one of the --results file(s). Writing "
+                "there would overwrite a results file that cost money to "
+                "produce, and the submission carries none of what it holds. "
+                "Choose a different --out."
+            )
+
     rows = build_submission(results, arm=arm, model=model, tasks=tasks)
+    if not rows:
+        raise SubmissionError(
+            f"no tasks to submit: --tasks yielded {len(tasks)} task(s). An "
+            "empty submission would be written as a single blank line and "
+            "look like a finished file. Check the --tasks path."
+        )
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
     return len(rows)

--- a/experiments/dabstep-contract-eval/dce/submit.py
+++ b/experiments/dabstep-contract-eval/dce/submit.py
@@ -1,0 +1,137 @@
+"""Build the DABStep leaderboard submission file from results rows.
+
+A submission is effectively ONE-SHOT per agent name, and the leaderboard
+Space grades whatever it is handed: a file quietly missing 12 of the 450
+tasks scores as 12 wrong answers, with no error raised anywhere and no way
+to take it back. So every check in this module is about REFUSING to write a
+file rather than about writing a good one -- the failure this guards against
+is silent, public and unrecoverable.
+
+Why an exporter exists at all: the reason to submit is not the ranking (see
+`docs/paper-plan.md`). It is that every submission publishes a per-task
+verdict from DABStep's own withheld golds, which turns "our reconstructed
+golds are probably right" -- the one caveat in FINDINGS a reader cannot
+check for themselves -- into a measured agreement rate.
+
+Row selection goes through `latest_rows`, so a retried unit contributes its
+final state rather than a stale `error` row's empty answer. Reading the file
+line by line instead would submit that empty string and score zero on a task
+the sweep actually got right.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from dce.runner import latest_rows
+from dce.stats import ANSWER_VERDICTS, UNGRADED_VERDICTS
+
+#: Verdicts carrying an answer the model actually produced. `ungraded` is
+#: included deliberately: it means no gold existed LOCALLY to score against,
+#: which is precisely the case the leaderboard's withheld golds resolve.
+#: Everything else in `dce.stats.HARNESS_VERDICTS` is the harness failing,
+#: and its `answer` is an empty string or an exception message.
+SUBMITTABLE_VERDICTS: frozenset[str] = ANSWER_VERDICTS | UNGRADED_VERDICTS
+
+
+class SubmissionError(Exception):
+    """The rows cannot produce a complete, submittable file."""
+
+
+def build_submission(
+    results: list[Path], *, arm: str, model: str, tasks: list[dict]
+) -> list[dict]:
+    """`{"task_id", "agent_answer"}` for every task in `tasks`, in `tasks`
+    order, taken from `arm`/`model` rows across `results`.
+
+    Several results files are accepted so the golded tasks from one sweep
+    and the ungolded ones from a later run can be spliced. Later files win
+    on a shared key, matching `latest_rows`' within-file rule.
+
+    Raises `SubmissionError`, naming the offending task ids, if any task has
+    no row, a row that is a harness failure rather than an answer, or a row
+    whose answer is blank.
+    """
+    by_task: dict[str, dict] = {}
+    for path in results:
+        for row in latest_rows(path):
+            if row.get("arm") == arm and row.get("model") == model:
+                by_task[row["task_id"]] = row
+
+    out: list[dict] = []
+    missing: list[str] = []
+    unusable: list[str] = []
+    blank: list[str] = []
+    for task in tasks:
+        task_id = task["task_id"]
+        row = by_task.get(task_id)
+        if row is None:
+            missing.append(task_id)
+            continue
+        verdict = row.get("verdict")
+        if verdict not in SUBMITTABLE_VERDICTS:
+            unusable.append(f"{task_id} ({verdict})")
+            continue
+        answer = row.get("answer") or ""
+        if not answer.strip():
+            blank.append(task_id)
+            continue
+        out.append({"task_id": task_id, "agent_answer": answer})
+
+    problems = []
+    if missing:
+        problems.append(f"no {arm} row on {model}: {', '.join(missing)}")
+    if unusable:
+        problems.append(f"harness failure, not an answer: {', '.join(unusable)}")
+    if blank:
+        problems.append(f"empty answer: {', '.join(blank)}")
+    if problems:
+        raise SubmissionError(
+            f"{len(missing) + len(unusable) + len(blank)} of {len(tasks)} tasks "
+            f"cannot be submitted -- "
+            + "; ".join(problems)
+            + ". Re-run them (`--retry`) rather than submitting a short file: "
+            "the leaderboard scores a missing task as wrong and a submission "
+            "cannot be withdrawn."
+        )
+    return out
+
+
+def write_submission(
+    out: Path, results: list[Path], *, arm: str, model: str, tasks: list[dict]
+) -> int:
+    """Write the submission JSONL and return how many tasks it covers.
+
+    The file is built in full BEFORE anything is written, so a refusal
+    leaves no partial file on disk -- a half-written submission is the
+    artifact most likely to be uploaded by mistake weeks later.
+    """
+    rows = build_submission(results, arm=arm, model=model, tasks=tasks)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+    return len(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="dce.submit")
+    parser.add_argument("--results", type=Path, nargs="+", required=True)
+    parser.add_argument("--arm", default="contract")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tasks", type=Path, default=Path("data/tasks.json"))
+    parser.add_argument("--out", type=Path, default=Path("submission.jsonl"))
+    args = parser.parse_args()
+
+    tasks = json.loads(args.tasks.read_text())
+    try:
+        n = write_submission(
+            args.out, args.results, arm=args.arm, model=args.model, tasks=tasks
+        )
+    except SubmissionError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(f"wrote {n} answers to {args.out} ({args.arm} on {args.model})")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/dabstep-contract-eval/dce/submit.py
+++ b/experiments/dabstep-contract-eval/dce/submit.py
@@ -56,6 +56,68 @@ class SubmissionError(Exception):
     """The rows cannot produce a complete, submittable file."""
 
 
+#: Provenance fields stamped on every result row. A splice that disagrees on
+#: `contract_digest` is two different agents and is refused outright: the
+#: contract IS the treatment, so a mid-splice edit means the per-task verdicts
+#: the submission buys no longer describe the arm the paper reports.
+#:
+#: `commit_sha` and `scorer` are reported, not refused. A splice spans two
+#: commits BY CONSTRUCTION -- the 49 ungolded tasks can only run once the code
+#: admitting them is committed -- so refusing on it would ban the documented
+#: flow.
+FATAL_PROVENANCE: tuple[str, ...] = ("contract_digest",)
+REPORTED_PROVENANCE: tuple[str, ...] = ("commit_sha", "scorer", "golds_hash")
+
+
+def _select(results: list[Path], *, arm: str, model: str) -> dict[str, dict]:
+    """task_id -> the row to submit, across every results file.
+
+    Later files win on a shared key, matching `latest_rows`' within-file
+    rule. One function so `provenance` and `build_submission` can never
+    disagree about which rows are in play.
+    """
+    by_task: dict[str, dict] = {}
+    for path in results:
+        for row in latest_rows(path):
+            if row.get("arm") == arm and row.get("model") == model:
+                by_task[row["task_id"]] = row
+    return by_task
+
+
+def _distinct(rows, field: str) -> list[str]:
+    return sorted({str(row[field]) for row in rows if row.get(field) is not None})
+
+
+def _assert_one_agent(rows) -> None:
+    """Refuse a submission assembled from two different contracts."""
+    rows = list(rows)
+    for field in FATAL_PROVENANCE:
+        values = _distinct(rows, field)
+        if len(values) > 1:
+            raise SubmissionError(
+                f"the selected rows disagree on {field}: {', '.join(values)}. "
+                "That is two different agents in one submission -- the "
+                "per-task verdicts it buys would not describe either arm. "
+                "Re-run the whole task set against one contract."
+            )
+
+
+def provenance(results: list[Path], *, arm: str, model: str) -> dict[str, list[str]]:
+    """Provenance fields the selected rows DISAGREE on, field -> values.
+
+    Empty when the rows are homogeneous. A divergence here is allowed but
+    must be visible: the operator is about to spend a one-shot, unwithdrawable
+    submission on it.
+    """
+    rows = list(_select(results, arm=arm, model=model).values())
+    diverged: dict[str, list[str]] = {}
+    for field in REPORTED_PROVENANCE:
+        values = _distinct(rows, field)
+        if len(values) > 1:
+            diverged[field] = values
+    return diverged
+
+
 def build_submission(
     results: list[Path], *, arm: str, model: str, tasks: list[dict]
 ) -> list[dict]:
@@ -70,11 +132,8 @@ def build_submission(
     no row, a row that is a harness failure rather than an answer, or a row
     whose answer is blank.
     """
-    by_task: dict[str, dict] = {}
-    for path in results:
-        for row in latest_rows(path):
-            if row.get("arm") == arm and row.get("model") == model:
-                by_task[row["task_id"]] = row
+    by_task = _select(results, arm=arm, model=model)
+    _assert_one_agent(by_task.values())
 
     out: list[dict] = []
     missing: list[str] = []
@@ -174,6 +233,10 @@ def main() -> None:
         )
     except SubmissionError as exc:
         raise SystemExit(str(exc)) from exc
+    for field, values in provenance(
+        args.results, arm=args.arm, model=args.model
+    ).items():
+        print(f"note: spliced rows disagree on {field}: {', '.join(values)}")
     print(f"wrote {n} answers to {args.out} ({args.arm} on {args.model})")
 
 

--- a/experiments/dabstep-contract-eval/dce/submit.py
+++ b/experiments/dabstep-contract-eval/dce/submit.py
@@ -28,12 +28,28 @@ from pathlib import Path
 from dce.runner import latest_rows
 from dce.stats import ANSWER_VERDICTS, UNGRADED_VERDICTS
 
-#: Verdicts carrying an answer the model actually produced. `ungraded` is
-#: included deliberately: it means no gold existed LOCALLY to score against,
-#: which is precisely the case the leaderboard's withheld golds resolve.
-#: Everything else in `dce.stats.HARNESS_VERDICTS` is the harness failing,
-#: and its `answer` is an empty string or an exception message.
-SUBMITTABLE_VERDICTS: frozenset[str] = ANSWER_VERDICTS | UNGRADED_VERDICTS
+#: Verdicts carrying an answer the model actually produced.
+#:
+#: `ungraded` is included deliberately: it means no gold existed LOCALLY to
+#: score against, which is precisely the case the leaderboard's withheld
+#: golds resolve.
+#:
+#: `scoring_error` too, for a sharper reason. `dce.agent` sets it only when a
+#: real answer came back and OUR scorer raised comparing it to the gold --
+#: the answer is intact (a test asserts the scorer failure never overwrites
+#: it), and whether it is right is the leaderboard's call, not ours.
+#: Excluding it would also be a dead end: `--retry` accepts only `error` and
+#: `post_run_error`, and `completed_keys` treats `scoring_error` as done, so
+#: no resumed sweep would re-run the task and the file could not be built
+#: without hand-editing results JSONL.
+#:
+#: The rest of `dce.stats.HARNESS_VERDICTS` stays out: `hit_limit`, `error`,
+#: `post_run_error` and `construction_error` carry an empty answer or an
+#: exception message, never a reply. The `answer.strip()` gate below is the
+#: backstop if that ever stops being true.
+SUBMITTABLE_VERDICTS: frozenset[str] = (
+    ANSWER_VERDICTS | UNGRADED_VERDICTS | {"scoring_error"}
+)
 
 
 class SubmissionError(Exception):
@@ -92,9 +108,11 @@ def build_submission(
             f"{len(missing) + len(unusable) + len(blank)} of {len(tasks)} tasks "
             f"cannot be submitted -- "
             + "; ".join(problems)
-            + ". Re-run them (`--retry`) rather than submitting a short file: "
-            "the leaderboard scores a missing task as wrong and a submission "
-            "cannot be withdrawn."
+            + ". Fix them rather than submitting a short file -- the "
+            "leaderboard scores a missing task as wrong and a submission "
+            "cannot be withdrawn. `error`/`post_run_error` rows re-run under "
+            "`dce.runner --retry`; the rest need the task re-run into a fresh "
+            "results file, which `--results` will then merge."
         )
     return out
 

--- a/experiments/dabstep-contract-eval/tests/test_agent.py
+++ b/experiments/dabstep-contract-eval/tests/test_agent.py
@@ -1803,3 +1803,67 @@ def test_reasoning_tokens_are_read_under_both_provider_spellings():
     assert agent._reasoning_tokens(_Usage(None)) == 0
     assert agent._reasoning_tokens(None) == 0
     assert agent._reasoning_tokens(_Usage({"thinking_tokens": None})) == 0
+
+
+# ── ungolded tasks: run them, but never grade them ────────────────────────
+
+
+def test_run_task_leaves_a_task_with_no_gold_ungraded(tmp_path: Path, monkeypatch):
+    """49 of DABStep's 450 tasks have no reconstructed gold. A leaderboard
+    submission has to ANSWER them, but there is nothing to score against —
+    and scoring against the `""` that `dict.get` would hand back grades
+    every one of them `incorrect`, which then enters `dce.stats`'
+    accuracy denominators as a real wrong answer.
+
+    `gold=None` is the explicit "no gold exists" signal: the answer is
+    recorded, `score` is never called, and the verdict is `ungraded`.
+    """
+    import dce.agent as agent_module
+
+    def _must_not_run(_predicted, _gold):
+        raise AssertionError("score() must not be called when there is no gold")
+
+    monkeypatch.setattr(agent_module, "score", _must_not_run)
+
+    class Fake:
+        def run_sync(self, *a, usage=None, **k):
+            return _fake_result("0.12", usage)
+
+    row = run_task(
+        TASK,
+        "contract",
+        "z-ai/glm-5.3-flash",
+        tmp_path / "x.duckdb",
+        {"manual": "m", "payments_readme": "r"},
+        gold=None,
+        golds_hash="deadbeef",
+        agent_factory=lambda **_: Fake(),
+    )
+    assert row["verdict"] == "ungraded"
+    assert row["answer"] == "0.12"
+    assert row["gold"] is None
+
+
+def test_run_task_still_grades_a_task_whose_gold_is_the_empty_string(
+    tmp_path: Path,
+):
+    """`None` means "no gold exists"; `""` is a real (if degenerate) gold and
+    must still be scored. Conflating the two is what makes an ungolded task
+    silently gradeable, so the distinction is asserted rather than assumed.
+    """
+
+    class Fake:
+        def run_sync(self, *a, usage=None, **k):
+            return _fake_result("0.12", usage)
+
+    row = run_task(
+        TASK,
+        "contract",
+        "z-ai/glm-5.3-flash",
+        tmp_path / "x.duckdb",
+        {"manual": "m", "payments_readme": "r"},
+        gold="",
+        golds_hash="deadbeef",
+        agent_factory=lambda **_: Fake(),
+    )
+    assert row["verdict"] in {"correct", "incorrect"}

--- a/experiments/dabstep-contract-eval/tests/test_runner.py
+++ b/experiments/dabstep-contract-eval/tests/test_runner.py
@@ -2681,3 +2681,31 @@ def test_sweep_hands_run_task_none_not_empty_string_for_an_ungolded_task(
     )
 
     assert seen == {"1": "a", "2": None}
+
+
+def test_the_default_submission_file_does_not_dirty_the_tree(tmp_path: Path):
+    """`assert_clean_tree` refuses to start a scored sweep on any dirty line
+    from `git status --porcelain`, exempting only the sweep's own `--out` and
+    its two sidecars. `dce.submit`'s default `--out submission.jsonl` is
+    neither, so an un-ignored submission file blocks the NEXT runner
+    invocation entirely — a `--max-spend` truncation resume (which
+    `deploy/supervise.sh` does automatically on exit 2), a `--retry` pass, or
+    another model's sweep.
+
+    This is the same failure `.gitignore` already records having measured for
+    leftover `.snapshot` files.
+    """
+    import subprocess
+
+    repo_root = Path(__file__).resolve().parents[3]
+    target = "experiments/dabstep-contract-eval/submission.jsonl"
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", target],
+        cwd=repo_root,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, (
+        f"{target} is not gitignored, so building a submission leaves the "
+        "tree dirty and assert_clean_tree blocks the next sweep"
+    )

--- a/experiments/dabstep-contract-eval/tests/test_runner.py
+++ b/experiments/dabstep-contract-eval/tests/test_runner.py
@@ -2602,3 +2602,82 @@ def test_clean_tree_still_rejects_a_sidecar_of_a_different_run(tmp_path: Path):
             repo_root=tmp_path,
             git_status_fn=lambda: "?? results/glm-full.jsonl.bak\n",
         )
+
+
+# ── ungolded tasks: runnable for a submission, never scored ───────────────
+
+
+def test_select_tasks_skips_ungolded_tasks_by_default():
+    """The scoring sweeps must keep their published task set exactly. A task
+    with no reconstructed gold cannot be scored, so it is not run.
+    """
+    from dce.runner import select_tasks
+
+    tasks = [{"task_id": "1"}, {"task_id": "2"}, {"task_id": "3"}]
+    golds = {"1": "a", "3": "c"}
+
+    assert [t["task_id"] for t in select_tasks(tasks, golds)] == ["1", "3"]
+
+
+def test_select_tasks_run_admits_tasks_with_no_gold():
+    """A leaderboard submission needs an answer for all 450 tasks, including
+    the 49 no consensus rule could reconstruct.
+    """
+    from dce.runner import select_tasks
+
+    tasks = [{"task_id": "1"}, {"task_id": "2"}, {"task_id": "3"}]
+    golds = {"1": "a", "3": "c"}
+
+    assert [t["task_id"] for t in select_tasks(tasks, golds, ungolded="run")] == [
+        "1",
+        "2",
+        "3",
+    ]
+
+
+def test_select_tasks_rejects_an_unknown_ungolded_mode():
+    from dce.runner import select_tasks
+
+    with pytest.raises(ValueError, match="ungolded"):
+        select_tasks([{"task_id": "1"}], {}, ungolded="sometimes")
+
+
+def test_sweep_hands_run_task_none_not_empty_string_for_an_ungolded_task(
+    tmp_path: Path,
+):
+    """`golds.get(task_id, "")` would hand `""` to `run_task`, which grades it
+    and returns `incorrect` — a fabricated wrong answer on a task that has no
+    right answer to compare against. The absence of a gold has to reach
+    `run_task` as `None`.
+    """
+    seen: dict[str, object] = {}
+
+    def fake_run(task, arm, model, working, docs, gold, **k):
+        seen[task["task_id"]] = gold
+        return {
+            "task_id": task["task_id"],
+            "arm": arm,
+            "model": model,
+            "usd": 0.0,
+            "usd_guard": 0.0,
+            "verdict": "ungraded" if gold is None else "correct",
+        }
+
+    tasks = [
+        {"task_id": "1", "question": "q", "guidelines": "g", "level": "hard"},
+        {"task_id": "2", "question": "q", "guidelines": "g", "level": "hard"},
+    ]
+    sweep(
+        tasks,
+        ("contract",),
+        (GLM,),
+        {"1": "a"},
+        out=tmp_path / "r.jsonl",
+        db_path=_make_pristine(tmp_path),
+        docs={},
+        max_spend=100.0,
+        golds_hash="h",
+        run_task_fn=fake_run,
+    )
+
+    assert seen == {"1": "a", "2": None}

--- a/experiments/dabstep-contract-eval/tests/test_runner.py
+++ b/experiments/dabstep-contract-eval/tests/test_runner.py
@@ -2688,9 +2688,10 @@ def test_the_default_submission_file_does_not_dirty_the_tree(tmp_path: Path):
     from `git status --porcelain`, exempting only the sweep's own `--out` and
     its two sidecars. `dce.submit`'s default `--out submission.jsonl` is
     neither, so an un-ignored submission file blocks the NEXT runner
-    invocation entirely — a `--max-spend` truncation resume (which
-    `deploy/supervise.sh` does automatically on exit 2), a `--retry` pass, or
-    another model's sweep.
+    invocation entirely — a `--max-spend` truncation resume, a `--retry`
+    pass, or another model's sweep. (`deploy/supervise.sh` does NOT retry
+    exit 2; it reports and exits. The blocked invocation is the operator's
+    next one.)
 
     This is the same failure `.gitignore` already records having measured for
     leftover `.snapshot` files.
@@ -2708,4 +2709,20 @@ def test_the_default_submission_file_does_not_dirty_the_tree(tmp_path: Path):
     assert result.returncode == 0, (
         f"{target} is not gitignored, so building a submission leaves the "
         "tree dirty and assert_clean_tree blocks the next sweep"
+    )
+
+    # ...but ANCHORED. An unanchored `submission*.jsonl` matches at every
+    # depth, including `results/submission.jsonl` -- a paid sweep's output.
+    # `results/` is deliberately tracked: the tamper-evidence claim depends
+    # on result rows being readable in git history.
+    in_results = "experiments/dabstep-contract-eval/results/submission.jsonl"
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", in_results],
+        cwd=repo_root,
+        capture_output=True,
+    )
+
+    assert result.returncode != 0, (
+        f"{in_results} is gitignored — an unanchored rule is swallowing a "
+        "results file, which must stay tracked as evidence"
     )

--- a/experiments/dabstep-contract-eval/tests/test_stats.py
+++ b/experiments/dabstep-contract-eval/tests/test_stats.py
@@ -157,6 +157,20 @@ def _arm_line(text: str, arm: str) -> str:
     return next(line for line in text.splitlines() if line.startswith(prefix))
 
 
+def _arm_block(text: str, arm: str) -> str:
+    """`_arm_line` plus the continuation lines belonging to it -- failures,
+    ungraded, db_corrupted. `_arm_line` alone matches only the header, so an
+    assertion about the failure line silently searches the wrong string.
+    """
+    prefix = f"{arm:16s}"
+    lines = text.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(prefix))
+    end = start + 1
+    while end < len(lines) and lines[end].startswith(" " * 16):
+        end += 1
+    return "\n".join(lines[start:end])
+
+
 def test_report_scores_the_deduped_row_not_all_three_stale_attempts(tmp_path):
     # A retried unit: two stale construction_error rows, then a real
     # success, all for (task_id="t1", arm=contract, model=PRIMARY_MODEL).
@@ -596,3 +610,70 @@ def test_report_drops_verified_wrong_gold_tasks(tmp_path):
     assert "60" in out.split("\n")[0]
     # The surviving task is the only one counted.
     assert "1/1" in out
+
+
+# ── ungraded rows: present in the file, absent from every denominator ─────
+
+
+def test_ungraded_rows_move_neither_accuracy(tmp_path):
+    """A task with no reconstructed gold is answered but not scored. It is
+    not a wrong answer, so it belongs in no numerator and no denominator —
+    including STRICT's, which does count harness failures against an arm.
+    """
+    rows = [
+        _row("t1", PRIMARY_RIGHT_ARM, "correct"),
+        _row("t2", PRIMARY_RIGHT_ARM, "ungraded"),
+        _row("t3", PRIMARY_RIGHT_ARM, "ungraded"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    line = _arm_line(report(path), PRIMARY_RIGHT_ARM)
+
+    assert "scored    1/1" in line
+    assert "strict    1/1" in line
+
+
+def test_ungraded_rows_are_not_counted_as_harness_failures(tmp_path):
+    """`ungraded` is a deliberate non-scoring, not the harness breaking. If
+    it landed in the failure numerator every submission run would look
+    HARNESS-LIMITED; if it landed only in the denominator it would dilute a
+    real failure rate and hide one.
+    """
+    rows = [_row(f"t{i}", PRIMARY_RIGHT_ARM, "correct") for i in range(9)]
+    rows.append(_row("t9", PRIMARY_RIGHT_ARM, "error"))
+    rows += [_row(f"u{i}", PRIMARY_RIGHT_ARM, "ungraded") for i in range(90)]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    block = _arm_block(report(path), PRIMARY_RIGHT_ARM)
+
+    # 1 error in 10 graded-or-failed rows: 10%, not 1% of 100.
+    assert "failures (10% of rows)" in block
+    assert "HARNESS-LIMITED" in block
+
+
+def test_report_names_the_ungraded_rows_it_set_aside(tmp_path):
+    """Dropping rows silently is a claim that they did not exist. The count
+    is printed so a reader can see the submission run's 49 unscoreable tasks
+    were excluded on purpose rather than lost.
+    """
+    rows = [
+        _row("t1", PRIMARY_RIGHT_ARM, "correct"),
+        _row("t2", PRIMARY_RIGHT_ARM, "ungraded"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    assert "ungraded=1" in _arm_block(report(path), PRIMARY_RIGHT_ARM)
+
+
+def test_report_says_nothing_about_ungraded_rows_when_there_are_none(tmp_path):
+    """Every published run has zero. The line must not appear and clutter
+    the four runs already in FINDINGS.
+    """
+    rows = [_row("t1", PRIMARY_RIGHT_ARM, "correct")]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    assert "ungraded" not in report(path)

--- a/experiments/dabstep-contract-eval/tests/test_stats.py
+++ b/experiments/dabstep-contract-eval/tests/test_stats.py
@@ -677,3 +677,65 @@ def test_report_says_nothing_about_ungraded_rows_when_there_are_none(tmp_path):
     _write(path, rows)
 
     assert "ungraded" not in report(path)
+
+
+def test_ungraded_rows_keep_their_cost_and_corruption(tmp_path):
+    """`_summarize` drops ungraded rows from the ACCURACY arithmetic only.
+    They are real runs: they were billed, and their working copy really was
+    checked. Dropping them from `usd_final` makes the cost line disagree with
+    `billed` for a reason the module docstring assigns to superseded
+    duplicates, and dropping them from `db_corrupted` silently deletes the
+    experiment's headline governance finding on 49 of 450 tasks.
+    """
+    rows = [
+        {**_row("t1", PRIMARY_RIGHT_ARM, "correct", usd=0.01), "db_corrupted": False},
+        {**_row("t2", PRIMARY_RIGHT_ARM, "ungraded", usd=0.05), "db_corrupted": True},
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    block = _arm_block(report(path), PRIMARY_RIGHT_ARM)
+
+    assert "db_corrupted: true=1" in block
+    assert "final=$0.06" in block
+
+
+def test_per_level_strict_accuracy_excludes_ungraded_rows(tmp_path):
+    """The level breakdown reads `arm_rows` directly rather than going
+    through `_summarize`, so it is a second denominator that has to exclude
+    them — otherwise the header prints `strict 1/1` and the level line
+    beneath it prints `strict 1/3` off the same rows.
+    """
+    rows = [
+        _row("t1", PRIMARY_RIGHT_ARM, "correct", level="easy"),
+        _row("t2", PRIMARY_RIGHT_ARM, "ungraded", level="easy"),
+        _row("t3", PRIMARY_RIGHT_ARM, "ungraded", level="easy"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    text = report(path)
+
+    assert "strict   1/1" in text
+    assert "strict   1/3" not in text
+
+
+def test_strict_mcnemar_does_not_pair_ungraded_tasks(tmp_path):
+    """STRICT pairing counts a harness failure as wrong — a real attempt that
+    produced no right answer. An ungraded task is not that: neither arm could
+    be graded on it, so pairing them inflates `n_paired` with tasks the test
+    says nothing about.
+    """
+    rows = [
+        _row("t1", PRIMARY_LEFT_ARM, "correct"),
+        _row("t1", PRIMARY_RIGHT_ARM, "correct"),
+        _row("t2", PRIMARY_LEFT_ARM, "ungraded"),
+        _row("t2", PRIMARY_RIGHT_ARM, "ungraded"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    text = report(path)
+
+    assert "n_paired=2" not in text
+    assert "n_paired=1" in text

--- a/experiments/dabstep-contract-eval/tests/test_stats.py
+++ b/experiments/dabstep-contract-eval/tests/test_stats.py
@@ -848,3 +848,25 @@ def test_strict_mcnemar_drops_an_ungolded_task_that_failed_the_harness(tmp_path)
 
     assert "n_paired=2" not in text
     assert "n_paired=1" in text
+
+
+def test_an_ungolded_only_arm_does_not_trip_the_unequal_task_set_warning(tmp_path):
+    """`--ungolded run --arms contract` resumed into an existing multi-arm
+    results file is the only way to run the 49 without re-paying for the 401.
+    It leaves the contract arm holding rows no other arm has — which is
+    exactly what this warning looks for, and here it is not a lopsided sweep.
+    Firing tells the operator to pay to run 49 unscoreable tasks on three
+    more arms, while every denominator above the warning is already correct.
+    """
+    rows = [
+        {**_row(f"t{i}", arm, "correct"), "gold": "a"}
+        for i in range(3)
+        for arm in (PRIMARY_LEFT_ARM, PRIMARY_RIGHT_ARM)
+    ] + [
+        _ungolded("u1", PRIMARY_RIGHT_ARM, "ungraded"),
+        _ungolded("u2", PRIMARY_RIGHT_ARM, "ungraded"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    assert "did NOT see the same task set" not in report(path)

--- a/experiments/dabstep-contract-eval/tests/test_stats.py
+++ b/experiments/dabstep-contract-eval/tests/test_stats.py
@@ -665,7 +665,7 @@ def test_report_names_the_ungraded_rows_it_set_aside(tmp_path):
     path = tmp_path / "results.jsonl"
     _write(path, rows)
 
-    assert "ungraded=1" in _arm_block(report(path), PRIMARY_RIGHT_ARM)
+    assert "ungolded: 1 row(s)" in _arm_block(report(path), PRIMARY_RIGHT_ARM)
 
 
 def test_report_says_nothing_about_ungraded_rows_when_there_are_none(tmp_path):
@@ -676,7 +676,7 @@ def test_report_says_nothing_about_ungraded_rows_when_there_are_none(tmp_path):
     path = tmp_path / "results.jsonl"
     _write(path, rows)
 
-    assert "ungraded" not in report(path)
+    assert "ungolded" not in report(path)
 
 
 def test_ungraded_rows_keep_their_cost_and_corruption(tmp_path):
@@ -739,3 +739,91 @@ def test_strict_mcnemar_does_not_pair_ungraded_tasks(tmp_path):
 
     assert "n_paired=2" not in text
     assert "n_paired=1" in text
+
+
+def _ungolded(task_id: str, arm: str, verdict: str, **kw) -> dict:
+    """A row for a task admitted by `--ungolded run`: no gold exists."""
+    return {**_row(task_id, arm, verdict, **kw), "gold": None}
+
+
+def test_an_ungolded_task_that_fails_the_harness_stays_out_of_the_arithmetic(
+    tmp_path,
+):
+    """An ungolded task only reaches `verdict: "ungraded"` if `run_task`
+    finishes cleanly. Trip a cap or error and the row keeps `hit_limit` /
+    `error` with `gold: null` — so a cut made on VERDICT lets it through into
+    `strict_n` and `failure_rate`, and `--ungolded run` moves numbers the
+    README promises it cannot. The cut has to be "this task has no gold".
+    """
+    rows = [
+        {**_row("t1", PRIMARY_RIGHT_ARM, "correct"), "gold": "a"},
+        {**_row("t2", PRIMARY_RIGHT_ARM, "correct"), "gold": "a"},
+        _ungolded("t3", PRIMARY_RIGHT_ARM, "hit_limit"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    text = report(path)
+    block = _arm_block(text, PRIMARY_RIGHT_ARM)
+
+    assert "strict    2/2" in block
+    assert "failures (0% of rows)" in block
+    assert "HARNESS-LIMITED" not in block
+    assert "strict   2/3" not in text
+
+
+def test_report_counts_the_harness_failures_among_ungolded_rows(tmp_path):
+    """Excluding ungolded rows from the failure rate must not HIDE a cap trip
+    on 49 tasks. They leave the rate — a different population — and are
+    reported on their own.
+    """
+    rows = [
+        {**_row("t1", PRIMARY_RIGHT_ARM, "correct"), "gold": "a"},
+        _ungolded("t2", PRIMARY_RIGHT_ARM, "ungraded"),
+        _ungolded("t3", PRIMARY_RIGHT_ARM, "hit_limit"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    block = _arm_block(report(path), PRIMARY_RIGHT_ARM)
+
+    assert "ungolded: 2 row(s)" in block
+    assert "1 harness failure(s)" in block
+
+
+def test_the_ungolded_count_is_not_printed_inside_the_failures_line(tmp_path):
+    """`failures (0% of rows): none, ungraded=49` reads as though 49 rows
+    were failures inside a line that just said 0%. It gets its own line.
+    """
+    rows = [
+        {**_row("t1", PRIMARY_RIGHT_ARM, "correct"), "gold": "a"},
+        _ungolded("t2", PRIMARY_RIGHT_ARM, "ungraded"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    failures_line = next(
+        line
+        for line in _arm_block(report(path), PRIMARY_RIGHT_ARM).splitlines()
+        if "failures (" in line
+    )
+    assert "ungolded" not in failures_line
+    assert "ungraded" not in failures_line
+
+
+def test_stale_scorer_warning_ignores_rows_that_were_never_graded(tmp_path):
+    """`ungraded` rows carry `scorer` like any other, but `rescore` skips
+    them. Counting them inflates the stale-scorer warning and makes its
+    claim — that every answered row has been re-graded — false for them.
+    """
+    rows = [
+        {**_row("t1", PRIMARY_RIGHT_ARM, "correct"), "gold": "a", "scorer": "fallback"},
+        {**_ungolded("t2", PRIMARY_RIGHT_ARM, "ungraded"), "scorer": "fallback"},
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    text = report(path)
+
+    assert "1 row(s)" in text
+    assert "2 row(s)" not in text

--- a/experiments/dabstep-contract-eval/tests/test_stats.py
+++ b/experiments/dabstep-contract-eval/tests/test_stats.py
@@ -827,3 +827,24 @@ def test_stale_scorer_warning_ignores_rows_that_were_never_graded(tmp_path):
 
     assert "1 row(s)" in text
     assert "2 row(s)" not in text
+
+
+def test_strict_mcnemar_drops_an_ungolded_task_that_failed_the_harness(tmp_path):
+    """`_strict_bools` made the verdict-keyed cut `_is_ungolded` exists to
+    replace. An ungolded task that trips a cap on one arm and errors on the
+    other keeps its harness verdicts, so a verdict cut pairs it — and the
+    report then prints `strict 1/1` per arm above an `n_paired=2` line.
+    """
+    rows = [
+        {**_row("t1", PRIMARY_LEFT_ARM, "correct"), "gold": "a"},
+        {**_row("t1", PRIMARY_RIGHT_ARM, "correct"), "gold": "a"},
+        _ungolded("u1", PRIMARY_LEFT_ARM, "hit_limit"),
+        _ungolded("u1", PRIMARY_RIGHT_ARM, "error"),
+    ]
+    path = tmp_path / "results.jsonl"
+    _write(path, rows)
+
+    text = report(path)
+
+    assert "n_paired=2" not in text
+    assert "n_paired=1" in text

--- a/experiments/dabstep-contract-eval/tests/test_submit.py
+++ b/experiments/dabstep-contract-eval/tests/test_submit.py
@@ -193,3 +193,28 @@ def test_write_submission_leaves_no_file_behind_when_it_refuses(tmp_path):
         write_submission(out, [results], arm="contract", model=MODEL, tasks=TASKS)
 
     assert not out.exists()
+
+
+def test_build_submission_accepts_a_scoring_error_answer(tmp_path):
+    """`scoring_error` is set only when a real, non-empty answer existed and
+    OUR scorer raised on it (see `dce.agent`). The answer is intact, and
+    whether it is right is exactly what the leaderboard's withheld golds
+    decide — so it is submittable.
+
+    Excluding it would also be a dead end: `--retry` accepts only `error`
+    and `post_run_error`, and `completed_keys` treats `scoring_error` as
+    done, so no resumed sweep would ever re-run the task. The submission
+    would be unbuildable without hand-editing the results file.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [
+            _row("1", "138236"),
+            _row("2", "A"),
+            _row("3", "yes", verdict="scoring_error"),
+        ],
+    )
+
+    out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert out[2] == {"task_id": "3", "agent_answer": "yes"}

--- a/experiments/dabstep-contract-eval/tests/test_submit.py
+++ b/experiments/dabstep-contract-eval/tests/test_submit.py
@@ -1,0 +1,195 @@
+"""The leaderboard submission file.
+
+A DABStep submission is effectively one-shot per agent name, and the Space
+grades whatever it is given: a file that is quietly short by 12 tasks scores
+as 12 wrong answers with no error anywhere. Every test here is about
+refusing to write such a file rather than about writing a good one.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from dce.submit import SubmissionError, build_submission, write_submission
+
+MODEL = "z-ai/glm-5.3-flash"
+TASKS = [
+    {"task_id": "1", "level": "easy"},
+    {"task_id": "2", "level": "hard"},
+    {"task_id": "3", "level": "hard"},
+]
+
+
+def _row(task_id: str, answer: str, *, verdict: str = "correct", arm: str = "contract"):
+    return {
+        "task_id": task_id,
+        "arm": arm,
+        "model": MODEL,
+        "answer": answer,
+        "verdict": verdict,
+    }
+
+
+def _write(path: Path, rows: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return path
+
+
+def test_build_submission_emits_task_id_and_agent_answer_for_every_task(tmp_path):
+    results = _write(
+        tmp_path / "r.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "yes")],
+    )
+
+    out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert out == [
+        {"task_id": "1", "agent_answer": "138236"},
+        {"task_id": "2", "agent_answer": "A"},
+        {"task_id": "3", "agent_answer": "yes"},
+    ]
+
+
+def test_build_submission_takes_only_the_requested_arm(tmp_path):
+    """Four arms answer every task. Submitting the wrong one, or a mixture,
+    is silent and unrecoverable.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [
+            _row("1", "contract-answer"),
+            _row("1", "schema-answer", arm="schema_only"),
+            _row("2", "A"),
+            _row("3", "yes"),
+        ],
+    )
+
+    out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert out[0] == {"task_id": "1", "agent_answer": "contract-answer"}
+
+
+def test_build_submission_takes_only_the_requested_model(tmp_path):
+    results = _write(
+        tmp_path / "r.jsonl",
+        [
+            {**_row("1", "other-model"), "model": "openai/gpt-5.6-sol"},
+            _row("1", "glm-answer"),
+            _row("2", "A"),
+            _row("3", "yes"),
+        ],
+    )
+
+    out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert out[0] == {"task_id": "1", "agent_answer": "glm-answer"}
+
+
+def test_build_submission_uses_the_last_row_for_a_retried_task(tmp_path):
+    """A resumed sweep leaves several rows for one key; only the last is that
+    unit's true state. This is `latest_rows`' contract, asserted here because
+    a submission that ships a stale `error` row's empty answer is a silent
+    zero on that task.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [
+            _row("1", "", verdict="error"),
+            _row("1", "138236"),
+            _row("2", "A"),
+            _row("3", "yes"),
+        ],
+    )
+
+    out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert out[0] == {"task_id": "1", "agent_answer": "138236"}
+
+
+def test_build_submission_merges_several_results_files(tmp_path):
+    """The splice case: the golded tasks from one sweep, the ungolded ones
+    from a later run.
+    """
+    a = _write(tmp_path / "a.jsonl", [_row("1", "138236"), _row("2", "A")])
+    b = _write(tmp_path / "b.jsonl", [_row("3", "yes", verdict="ungraded")])
+
+    out = build_submission([a, b], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert [r["task_id"] for r in out] == ["1", "2", "3"]
+
+
+def test_build_submission_accepts_an_ungraded_answer(tmp_path):
+    """`ungraded` means no gold existed locally — the answer is real, and it
+    is exactly what the leaderboard's withheld golds are there to judge.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "yes", verdict="ungraded")],
+    )
+
+    out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert out[2] == {"task_id": "3", "agent_answer": "yes"}
+
+
+def test_build_submission_refuses_when_a_task_is_missing(tmp_path):
+    results = _write(tmp_path / "r.jsonl", [_row("1", "138236"), _row("2", "A")])
+
+    with pytest.raises(SubmissionError, match="3"):
+        build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+
+def test_build_submission_refuses_a_harness_failure_row(tmp_path):
+    """`hit_limit` produced no answer. Shipping it as one submits an empty
+    string and scores zero on that task.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "", verdict="hit_limit")],
+    )
+
+    with pytest.raises(SubmissionError, match="hit_limit"):
+        build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+
+def test_build_submission_refuses_an_empty_answer(tmp_path):
+    """A graded-but-empty answer is a harness artifact far more often than a
+    real reply. Rerun the task; do not spend the one-shot submission on it.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "   ")],
+    )
+
+    with pytest.raises(SubmissionError, match="empty"):
+        build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
+
+
+def test_write_submission_writes_one_json_object_per_line(tmp_path):
+    results = _write(
+        tmp_path / "r.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "yes")],
+    )
+    out = tmp_path / "submission.jsonl"
+
+    write_submission(out, [results], arm="contract", model=MODEL, tasks=TASKS)
+
+    lines = out.read_text().splitlines()
+    assert [json.loads(line) for line in lines] == [
+        {"task_id": "1", "agent_answer": "138236"},
+        {"task_id": "2", "agent_answer": "A"},
+        {"task_id": "3", "agent_answer": "yes"},
+    ]
+
+
+def test_write_submission_leaves_no_file_behind_when_it_refuses(tmp_path):
+    """A partial file on disk is the thing most likely to get uploaded by
+    mistake later.
+    """
+    results = _write(tmp_path / "r.jsonl", [_row("1", "138236")])
+    out = tmp_path / "submission.jsonl"
+
+    with pytest.raises(SubmissionError):
+        write_submission(out, [results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert not out.exists()

--- a/experiments/dabstep-contract-eval/tests/test_submit.py
+++ b/experiments/dabstep-contract-eval/tests/test_submit.py
@@ -218,3 +218,35 @@ def test_build_submission_accepts_a_scoring_error_answer(tmp_path):
     out = build_submission([results], arm="contract", model=MODEL, tasks=TASKS)
 
     assert out[2] == {"task_id": "3", "agent_answer": "yes"}
+
+
+def test_write_submission_refuses_to_overwrite_one_of_its_inputs(tmp_path):
+    """`build_submission` reads everything into memory first, so writing over
+    a results file SUCCEEDS and replaces a paid sweep — verdicts, gold, cost,
+    instrumentation, trace pointers — with a two-field answer list. The
+    README's own recipe puts the sweep at `results/submission.jsonl` and the
+    export at `submission.jsonl`, one path component apart.
+    """
+    results = _write(
+        tmp_path / "r.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "yes")],
+    )
+
+    with pytest.raises(SubmissionError, match="results file"):
+        write_submission(results, [results], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert json.loads(results.read_text().splitlines()[0])["arm"] == "contract"
+
+
+def test_write_submission_refuses_to_write_an_empty_submission(tmp_path):
+    """A `--tasks` file that parses to `[]` finds no problems to report, so
+    the guards stay quiet and a file containing one blank line lands on disk
+    — precisely the artifact most likely to be uploaded weeks later.
+    """
+    results = _write(tmp_path / "r.jsonl", [_row("1", "138236")])
+    out = tmp_path / "submission.jsonl"
+
+    with pytest.raises(SubmissionError, match="no tasks"):
+        write_submission(out, [results], arm="contract", model=MODEL, tasks=[])
+
+    assert not out.exists()

--- a/experiments/dabstep-contract-eval/tests/test_submit.py
+++ b/experiments/dabstep-contract-eval/tests/test_submit.py
@@ -311,3 +311,40 @@ def test_provenance_names_every_field_the_spliced_rows_disagree_on(tmp_path):
 
     assert diverged["commit_sha"] == ["aaa", "bbb"]
     assert "scorer" not in diverged
+
+
+def test_build_submission_refuses_a_results_path_that_does_not_exist(tmp_path):
+    """`_read_rows` returns `[]` for a missing file without a word — right
+    for the runner (a fresh `--out`), wrong for an exporter whose whole
+    contract is refusing to write. A typo'd override contributes nothing, the
+    earlier file already covers all 450, no guard fires, and stale answers
+    ship on a one-shot submission.
+    """
+    a = _write(
+        tmp_path / "a.jsonl",
+        [_row("1", "138236"), _row("2", "A"), _row("3", "yes")],
+    )
+
+    with pytest.raises(SubmissionError, match="does not exist"):
+        build_submission(
+            [a, tmp_path / "typo.jsonl"], arm="contract", model=MODEL, tasks=TASKS
+        )
+
+
+def test_build_submission_refuses_when_one_side_has_no_contract_digest(tmp_path):
+    """For a FATAL provenance field, absent is the unknown-provenance case the
+    check exists to refuse — not one to skip. Skipping it means a splice
+    whose other half predates the field being stamped sees one distinct
+    value and passes.
+    """
+    a = _write(
+        tmp_path / "a.jsonl",
+        [
+            {**_row("1", "138236"), "contract_digest": "sha256:aaa"},
+            {**_row("2", "A"), "contract_digest": "sha256:aaa"},
+        ],
+    )
+    b = _write(tmp_path / "b.jsonl", [_row("3", "yes")])  # no contract_digest
+
+    with pytest.raises(SubmissionError, match="contract_digest"):
+        build_submission([a, b], arm="contract", model=MODEL, tasks=TASKS)

--- a/experiments/dabstep-contract-eval/tests/test_submit.py
+++ b/experiments/dabstep-contract-eval/tests/test_submit.py
@@ -250,3 +250,64 @@ def test_write_submission_refuses_to_write_an_empty_submission(tmp_path):
         write_submission(out, [results], arm="contract", model=MODEL, tasks=[])
 
     assert not out.exists()
+
+
+def test_build_submission_refuses_rows_from_two_different_contracts(tmp_path):
+    """The splice runs the 401 and the 49 at different times. If the contract
+    was edited in between, the submission is a mixture of two agents and the
+    per-task verdicts it buys no longer describe the paper's arm. The digest
+    is on every row; nothing was checking it.
+    """
+    a = _write(
+        tmp_path / "a.jsonl",
+        [
+            {**_row("1", "138236"), "contract_digest": "sha256:aaa"},
+            {**_row("2", "A"), "contract_digest": "sha256:aaa"},
+        ],
+    )
+    b = _write(
+        tmp_path / "b.jsonl", [{**_row("3", "yes"), "contract_digest": "sha256:bbb"}]
+    )
+
+    with pytest.raises(SubmissionError, match="contract_digest"):
+        build_submission([a, b], arm="contract", model=MODEL, tasks=TASKS)
+
+
+def test_build_submission_allows_a_splice_across_two_commits(tmp_path):
+    """`commit_sha` MUST be allowed to differ: the 49 ungolded tasks can only
+    run after the code admitting them is committed, so every splice spans two
+    commits by construction. Refusing here would ban the documented flow.
+    """
+    a = _write(
+        tmp_path / "a.jsonl",
+        [
+            {**_row("1", "138236"), "commit_sha": "aaa"},
+            {**_row("2", "A"), "commit_sha": "aaa"},
+        ],
+    )
+    b = _write(tmp_path / "b.jsonl", [{**_row("3", "yes"), "commit_sha": "bbb"}])
+
+    out = build_submission([a, b], arm="contract", model=MODEL, tasks=TASKS)
+
+    assert [r["task_id"] for r in out] == ["1", "2", "3"]
+
+
+def test_provenance_names_every_field_the_spliced_rows_disagree_on(tmp_path):
+    """A divergence that is allowed still has to be VISIBLE — the operator is
+    about to spend a one-shot submission on it.
+    """
+    from dce.submit import provenance
+
+    a = _write(
+        tmp_path / "a.jsonl",
+        [{**_row("1", "138236"), "commit_sha": "aaa", "scorer": "official"}],
+    )
+    b = _write(
+        tmp_path / "b.jsonl",
+        [{**_row("3", "yes"), "commit_sha": "bbb", "scorer": "official"}],
+    )
+
+    diverged = provenance([a, b], arm="contract", model=MODEL)
+
+    assert diverged["commit_sha"] == ["aaa", "bbb"]
+    assert "scorer" not in diverged


### PR DESCRIPTION
## What this unblocks

A DABStep leaderboard submission. The reason to submit is not the ranking —
`docs/paper-plan.md` disclaims competing on score — it is that every submission
publishes a per-task verdict from DABStep's **own withheld golds**, which turns
"our reconstructed golds are probably right" (the one caveat in `FINDINGS.md` a
reader cannot check for themselves) into a measured agreement rate.

Two things blocked it, and only one of them was the obvious one.

## Gap 1: the 49 ungolded tasks could never run

`dce.runner`'s `main` filtered the task list to `task_id in golds`. DABStep is
450 tasks; 401 have a reconstructable gold, so the ablation runs 401 — correct
for a scored sweep, fatal for a submission, which must answer all 450.

Now `select_tasks(tasks, golds, ungolded=...)`, defaulting to **`skip`**. Every
published sweep and every command in the README reproduces byte-for-byte; the
new behaviour is opt-in via `--ungolded run`.

## Gap 1b: lifting the filter naively is worse than leaving it

`_run_group` passed `golds.get(task_id, "")`. With the filter lifted, all 49
ungolded tasks would be scored against an empty gold, land as `incorrect`, and
enter every accuracy denominator in `dce.stats` as real wrong answers —
corrupting the four published runs, not just the new one.

The absence of a gold now reaches `run_task` as `None` and is recorded
`verdict: "ungraded"`: a **third verdict category**, in neither
`ANSWER_VERDICTS` nor `HARNESS_VERDICTS`. `_summarize` drops those rows ahead
of every count, which matters in two places that are easy to miss:

- `strict_n = len(rows)` — STRICT accuracy deliberately counts harness failures
  against an arm, so an ungraded row left in `rows` counts against it exactly
  as a wrong answer does.
- `failure_rate = sum(failures) / strict_n` shares that denominator, so
  ungraded rows would dilute a real harness-failure rate and could hide one
  below `HARNESS_FAILURE_RATE_THRESHOLD`.

`dce.stats` prints `ungraded=N` on any arm that has some, and nothing at all
when there are none — dropping rows silently is a claim that they did not
exist, and the four runs in FINDINGS must render unchanged.

## Gap 2: no submission exporter

`dce/submit.py` emits `{"task_id", "agent_answer"}` per line, reading through
`latest_rows` so a retried unit contributes its final answer rather than a
stale `error` row's empty string.

It **refuses to write at all**, leaving no partial file behind, if any task has
no row, a harness-failure verdict, or a blank answer — naming them. A
submission is effectively one-shot per agent name and the Space scores a
missing task as wrong, so a short file is worse than no file. `--results` takes
several files, so a fresh all-450 sweep and a spliced 401 + 49 both work.

Uploading is manual on purpose: the Space wants a browser and metadata a person
should enter.

## Verification

```
uv run pytest -q                 # 369 passed  (experiment, was 348)
cd ../.. && uv run pytest -q     # 1432 passed (library)
prek run --all-files             # ruff, ruff-format, ty, pygrep: all pass
```

Beyond the fixtures, against real data:

```
$ uv run python -m dce.submit --results results/glm-full.jsonl \
      --arm contract --model z-ai/glm-5.3-flash --out /tmp/x.jsonl
49 of 450 tasks cannot be submitted -- no contract row on z-ai/glm-5.3-flash: 1234, 2761, ...
$ echo $?
1
$ ls /tmp/x.jsonl
ls: /tmp/x.jsonl: No such file or directory
```

Exactly 49, matching `data/exclusions.json` (44 `below_plurality_threshold` +
5 `verified_wrong_gold`) — two independent paths agreeing on which tasks lack
golds.

## Not in this PR

No upload automation, and `dce.prepare` still reconstructs 401 golds. The 49
stay ungolded, which is the honest state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyQez99sqiCCuUAFVmytHj
