### PR TITLE
fix: the leniency correction tightens the run D band check, not breaks it

### DIFF
--- a/docs/paper/sections/05-results.tex
+++ b/docs/paper/sections/05-results.tex
@@ -135,12 +135,15 @@ side of it is 332 hard tasks graded against reconstructed golds; the band is
 hard split for the one arm it could measure. Correcting \armM{} by its own
 measured exposure rather than by that headline number
 (Section~\ref{sec:threats-golds}) gives $20.3\%$ on run~A, still inside the
-band. Run~D does not survive the same treatment: \armM{} is the single most
-exposed cell in Table~\ref{tab:leniency} at 40.5\%, and correcting it moves
-Sonnet~5 from 23.8\% to $18.2\%$, just below the 19.8\% comparator. We report
-the check as passing on run~A and as \emph{not} passing on run~D under
-correction. It is in any case a check against a band rather than a matched
-comparison, and Section~\ref{sec:threats-golds} should be read with it.
+band. It \emph{tightens} the run~D check rather than breaking it: \armM{} is
+the single most exposed cell in Table~\ref{tab:leniency} at 40.5\%, and
+correcting it moves Sonnet~5 from 23.8\% to $18.2\%$ --- from 4.0~pp above the
+officially-graded 19.8\% comparator to 1.6~pp below it. Both sides are then
+graded on something closer to the same footing, and part of the original
+overshoot was our own leniency rather than a real difference. That 40.5\% also
+makes this the least safe extrapolation in the analysis, applying a conversion
+rate measured on \armC{} and \texttt{glm} to the arm and model furthest from
+it; read $18.2\%$ as a direction, not a second measurement.
 
 The easy split gives a second, negative check. \armC{} is not the best arm on
 easy tasks in any of the four runs: \armM{} leads on all four (73.9\%,

--- a/experiments/dabstep-contract-eval/FINDINGS.md
+++ b/experiments/dabstep-contract-eval/FINDINGS.md
@@ -236,6 +236,19 @@ leaderboard measures. Run D supplies the same check on a second model family:
 Sonnet 5 with the manual in its prompt lands at **23.8%** hard, against the
 leaderboard's 19.8% for Claude 4 Sonnet under the same approach.
 
+The gold audit tightens that second check rather than loosening it. Our 23.8%
+is graded against reconstructed golds and their 19.8% officially, and Sonnet
+5's `manual_prompt` is the most leniency-exposed cell anywhere in these runs
+(40.5%, see [Is the leniency
+arm-neutral?](#is-the-leniency-arm-neutral-not-quite-and-not-in-one-direction)).
+Correcting it gives **18.2%** — moving us from 4.0 pp above the comparator to
+1.6 pp below it, with both sides then graded on something closer to the same
+footing. Part of the original overshoot was our own leniency. That 40.5% also
+makes this the least safe extrapolation in the analysis, applying a rate
+measured on glm's contract arm to the arm and model furthest from it; read
+18.2% as a direction, not a second measurement. Run A's corrected
+`manual_prompt`, 20.3%, stays inside the 20–26% band.
+
 On deepseek the same arm reaches **42.9%**, well above the published band.
 That is a statement about the model, not the harness: `deepseek-v4-flash` is
 simply stronger at this benchmark than the named baselines, and its


### PR DESCRIPTION
#96 claimed the run D harness-validity check "does not pass" once the gold leniency is corrected for. That reads the check backwards, and this fixes it.

## What the check is

`manual_prompt` is not just an arm — it is the harness-validity check. It reimplements the published approach (DABStep's `manual.md` pasted into the prompt), so if our harness measures what the leaderboard measures, it should land near published entries using that same approach.

- **Run A:** glm `manual_prompt` = 22.9%, against a published **band** of 20–26%. Inside it.
- **Run D:** a tighter, same-family version — our Sonnet 5 `manual_prompt` at 23.8% against HuggingFace's Claude 4 Sonnet entry at **19.8%**.

## What went wrong

Our 23.8% is graded against reconstructed golds; their 19.8% is graded officially. The gold audit showed our grading is lenient, so correcting ours makes the two comparable. That gives 18.2%.

| | vs the 19.8% comparator |
|---|---|
| raw 23.8% | 4.0 pp **above** |
| corrected 18.2% | 1.6 pp **below** |

The correction moves us *closer*, on a more comparable footing, and says part of the original 4-point overshoot was our own leniency rather than a real difference between the two systems. #96 called that a failed check.

The error was importing run A's "must stay inside the band" logic into run D, where there is no band — 19.8% is a single comparator, not a threshold. On run A the logic does apply, and `manual_prompt` corrects to 20.3%, still inside 20–26%.

## What is kept

Sonnet 5's `manual_prompt` is the most leniency-exposed cell anywhere in these runs (40.5%; next highest 36.8%), which makes 18.2% the least safe extrapolation in the whole analysis — it applies a conversion rate measured on glm's *contract* arm to the arm and model furthest from it. Both the paper and `FINDINGS.md` now report it as a direction rather than a second measurement.

Paper builds clean: 22 pages, 0 overfull boxes, all references resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyQez99sqiCCuUAFVmytHj