### PR TITLE
docs(examples): say that a declared column type is not verified

### DIFF
--- a/examples/revenue_agent/semantic.yml
+++ b/examples/revenue_agent/semantic.yml
@@ -87,10 +87,21 @@ tables:
   # `describe_table` renders all three, so a declaration here is the only way
   # column documentation reaches an agent.
   #
-  # These declarations are checked against the live warehouse by
+  # The *names* declared here are checked against the live warehouse by
   # `check_drift.py` — a column named here that no longer exists is reported
   # rather than silently dropped, which is what the `column_hints` note below
   # had to assert by hand.
+  #
+  # `type:` is NOT checked, and is worth understanding before you rely on it.
+  # Its only consumer is `dump_semantic_source`, so it reaches `contract_digest`
+  # and anyone reading this file — never the agent, which is always shown the
+  # warehouse's own type by `describe_table`, and never the system prompt. A
+  # wrong `type:` here is therefore inert at query time but frozen into the
+  # contract's attestation. It is carried because dbt, Cube and Ossie sources
+  # populate it from their manifests and the YAML format matches them; checking
+  # it needs type *equivalence* (BIGINT/INT64/NUMBER(38,0) are one type, and
+  # dbt's own hand-typed `DECIMAL` will not string-match a warehouse's
+  # `DECIMAL(10,2)`), which is deliberately not built yet — see issue #100.
   - schema: analytics
     table: orders
     description: >-


### PR DESCRIPTION
Follow-up to #99, and the counterpart to #100.

v0.51.0 added a `tables:` section to `examples/revenue_agent/semantic.yml` declaring a `type:` on all 14 columns. Tracing it afterwards: **nothing reads it.** Its only consumer is `dump_semantic_source`, so it reaches `contract_digest` and anyone reading the file — never the agent, which is always shown the warehouse's own type by `describe_table`, and never the system prompt.

An example that declares a field nothing verifies, without saying so, teaches the reader that types are checked when they are not. That is a small instance of the "delivers less than it appears to" defect v0.51.0 was about, planted in the example that demonstrates the fix.

The field is **kept rather than dropped**, because dbt, Cube and Ossie sources populate it from their manifests — it is genuinely part of the format, and removing it from the flagship example would make the format look narrower than it is. The comment names the gap and points at #100, which records why checking it needs type *equivalence* rather than string comparison.

Golden output is unchanged: a YAML comment prints nothing, and both `expected_output.txt` and `expected_drift_output.txt` diff clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyQez99sqiCCuUAFVmytHj