### PR TITLE
paper: make arxiv builds the upload bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ docs/paper/pvldb.log
 docs/paper/pvldb.out
 docs/paper/pvldb.bbl
 docs/paper/pvldb.blg
+
+# arXiv bundle (docs/paper: make arxiv)
+docs/paper/build/
+docs/paper/arxiv-*.tar.gz

--- a/docs/paper/Makefile
+++ b/docs/paper/Makefile
@@ -1,7 +1,7 @@
 # Two pdflatex passes bracket bibtex: the first writes the .aux bibtex reads,
 # and the last two resolve \ref and \cite forward references. Dropping either
 # trailing pass leaves "??" in the PDF.
-.PHONY: all clean check figures pvldb
+.PHONY: all clean check figures pvldb arxiv
 
 all: main.pdf
 
@@ -52,6 +52,24 @@ check: main.pdf pvldb.pdf
 	 echo "abstract.txt: $$c characters (arXiv cap 1920)"; test "$$c" -le 1920
 	@cd ../../experiments/dabstep-contract-eval && uv run python analysis/cost_decomposition.py --check
 
+# arXiv upload bundle: sources plus main.bbl (arXiv does not run BibTeX),
+# without pvldb.tex (a second top-level .tex reads as a second document),
+# refs.bib, the Makefile or the figure script. The bundle is compiled in a
+# clean directory first, the way arXiv will compile it.
+ARXIV := arxiv-$(shell date +%Y%m%d).tar.gz
+arxiv: main.pdf
+	rm -rf build/arxiv && mkdir -p build/arxiv/sections build/arxiv/figures
+	cp main.tex preamble.tex main.bbl build/arxiv/
+	cp sections/*.tex build/arxiv/sections/
+	cp $(FIGS) build/arxiv/figures/
+	cd build/arxiv && pdflatex -interaction=nonstopmode -halt-on-error main.tex >/dev/null \
+	  && pdflatex -interaction=nonstopmode -halt-on-error main.tex >/dev/null
+	@grep 'Reference.*undefined\|Citation.*undefined' build/arxiv/main.log && exit 1 || true
+	@grep -o 'Output written on main.pdf ([0-9]* pages' build/arxiv/main.log
+	tar -czf $(ARXIV) -C build/arxiv main.tex preamble.tex main.bbl sections figures
+	@echo "wrote $(ARXIV); the abstract for the form is abstract.txt"
+
 clean:
-	rm -f main.pdf main.aux main.log main.out main.bbl main.blg \
+	rm -rf build
+	rm -f arxiv-*.tar.gz main.pdf main.aux main.log main.out main.bbl main.blg \
 	      pvldb.pdf pvldb.aux pvldb.log pvldb.out pvldb.bbl pvldb.blg

--- a/docs/paper/README.md
+++ b/docs/paper/README.md
@@ -8,6 +8,7 @@ from [`../../experiments/dabstep-contract-eval/FINDINGS.md`](../../experiments/d
 make            # rebuild figures if stale, then main.pdf (extended, arXiv)
 make pvldb.pdf  # the PVLDB submission: acmart sigconf, no appendix
 make figures    # figures only
+make arxiv      # arXiv upload bundle, compiled in a clean directory first
 make check      # both builds: no overfull boxes, no unresolved refs,
                 # and the submission's content pages <= 12
 ```
@@ -82,9 +83,10 @@ and run `mktexlsr ~/Library/texmf`. A full TeX Live has all of this already.
 - **`motherduck-semantic` is dated from page metadata.** The page shows no
   byline or date, but its `datePublished` metadata says 8 June 2026, and the
   bib entry says so.
-- **arXiv build.** arXiv does not run BibTeX: upload `main.bbl` alongside the
-  sources. `\pdfoutput=1` is on line 1 of `main.tex` so its build picks
-  pdflatex for the PDF figures.
+- **arXiv build.** `make arxiv` writes the upload tarball: sources and
+  `main.bbl` (arXiv does not run BibTeX), no `pvldb.tex`, no `refs.bib`.
+  `\pdfoutput=1` is on line 1 of `main.tex` so arXiv picks pdflatex for the
+  PDF figures.
 - **arXiv abstract field.** `abstract.txt` is the plain-text abstract for
   the submission form; regenerate it if `sections/00-abstract.tex` changes.
   `make check` fails if it exceeds arXiv's 1,920-character cap.


### PR DESCRIPTION
Adds a `make arxiv` target that assembles the arXiv upload (sources, preamble, sections, figures, `main.bbl`), compiles it twice in a clean `build/arxiv` directory the way arXiv will, fails on unresolved references, and writes `arxiv-YYYYMMDD.tar.gz`. The bundle excludes `pvldb.tex` (a second top-level `.tex` reads as a second document), `refs.bib`, the Makefile and the figure script. Build artifacts are git-ignored; README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pdRZ5Zi4TQmww16XwNk49